### PR TITLE
Fix bug in addprinc: use -pw option

### DIFF
--- a/manifests/addprinc.pp
+++ b/manifests/addprinc.pp
@@ -8,7 +8,7 @@
 #
 define kerberos::addprinc($principal_name = $title, $password = 'password', $flags = '') {
   exec { "add_principal_$principal_name":
-    command => "kadmin.local -w '$password' -q 'addprinc $flags $principal_name'",
-    require => [ Package['krb5-kadmind-server-packages'], Exec['create_krb5kdc_principal'] ],
+    command => "kadmin.local -q 'addprinc $flags -pw $password $principal_name'",
+    require => [ Package['krb5-kadmind-server-packages'], Service['krb5-kdc'], ],
   }
 }


### PR DESCRIPTION
addprinc was using the -w option of kadmin.local instead of the -pw option of addprinc. The former is for authenicating access to kadmin.local (not necessary for root/admin@REALM, and therefore ignored), whereas the later is for setting the password of the new principal, which is what was meant.

This patch also makes addprinc require that the krb5-kdc service be running, as this is necessary for this command.
