### PR TITLE
Ensure that the krb5-admin-server is running.

### DIFF
--- a/manifests/server/kadmind.pp
+++ b/manifests/server/kadmind.pp
@@ -13,4 +13,13 @@ class kerberos::server::kadmind {
     ensure => present,
     name   => $kerberos::params::kadmin_server_packages,
   }
+
+  service { 'krb5-admin-server':
+    ensure     => running,
+    enable     => true,
+    hasrestart => true,
+    hasstatus  => true,
+    subscribe  => File['krb5.conf'],
+    require => Service["krb5-kdc"],
+  }
 }

--- a/manifests/server/kdc.pp
+++ b/manifests/server/kdc.pp
@@ -80,12 +80,4 @@ class kerberos::server::kdc($realm = 'EXAMPLE.COM', $master_password) inherits k
     subscribe  => File['kdc.conf'],
     require => Exec["create_krb5kdc_principal"],
   }
-  service { 'krb5-admin-server':
-    ensure     => running,
-    enable     => true,
-    hasrestart => true,
-    hasstatus  => true,
-    subscribe  => File['krb5.conf'],
-    require => Service["krb5-kdc"],
-  }
 }


### PR DESCRIPTION
This PR makes sure that the krb5-admin-server is started, allowing kadmin to work e.g. for those who cannot use kadmin.local.
