### PR TITLE
Fix typo in README: admin_server needs to be a string literal

### DIFF
--- a/README
+++ b/README
@@ -33,7 +33,7 @@ Example Use
       realm             => 'EXAMPLE.ORG',
       domain_realm      => { '.example.org' => 'EXAMPLE.ORG', },
       kdc               => ['cellserver.example.org'],
-      admin_server      => ['cellserver.example.org'],
+      admin_server      => 'cellserver.example.org',
       allow_weak_crypto => true,
     }
 


### PR DESCRIPTION
It was an array; using an array will build, but the services won't start.
