### PR TITLE
Enhance and rework module

### DIFF
--- a/README
+++ b/README
@@ -22,23 +22,37 @@ Example Use
 -----------
 
     # Kerberos server (kdc and kadmin)
-    include kerberos::server::kadmind
-
-    class {'kerberos::server::kdc':
+    class {'kerberos':
+      master => true,
       realm => 'EXAMPLE.ORG',
+      kdc_database_password => 'secret',
     }
 
     # kerberos client
-    class {'kerberos::client':
+    class {'kerberos':
+      client            => true,
       realm             => 'EXAMPLE.ORG',
       domain_realm      => { '.example.org' => 'EXAMPLE.ORG', },
-      kdc               => ['cellserver.example.org'],
+      kdcs              => ['cellserver.example.org'],
       admin_server      => 'cellserver.example.org',
       allow_weak_crypto => true,
     }
 
 Hiera Usage
 -----------
+
+Define all the main class parameters you'd like to change like this:
+
+kerberos::realm: 'EXAMPLE.ORG'
+kerberos::kdcs:
+  - 'cellserver.example.org'
+
+Forget about client => true. Just include or hiera_include() any of the
+following classes (perhaps not master and slave on the same box...):
+
+kerberos::client
+kerberos::kdc::master
+kerberos::kdc::slave
 
 It is best to store passwords in Hiera; that way, you can have a set of test
 credentials, and a different set of credentials for production servers.  For
@@ -65,7 +79,7 @@ in a more secure location.
 
   production.yaml:
   ---
-  kerberos::server::kdc::master_password: verylongsecurerandomlyproducedpassword
+  kerberos::kdc_database_password: verylongsecurerandomlyproducedpassword
 
   trusted_realms:
     realms:

--- a/manifests/addprinc.pp
+++ b/manifests/addprinc.pp
@@ -1,14 +1,57 @@
+# === Type: kerberos::addprinc
+#
+# Adds a kerberos principal to the KDC database. Supports use of kadmin.local
+# or kadmin. The latter supports use of a ticket cache or a keytab file.
+#
 # === Authors
 #
 # Author Name <greg.1.anderson@greenknowe.org>
+# Additions by Michael Weiser <michael.weiser@gmx.de>
 #
 # === Copyright
 #
 # Copyright 2014 Jason Edgecombe (Copyright assigned by original author)
 #
-define kerberos::addprinc($principal_name = $title, $password = 'password', $flags = '') {
+define kerberos::addprinc($principal_name = $title, $password = undef, $flags = '',
+  $local = true, $kadmin_ccache = undef, $keytab = undef,
+  $tries = undef, $try_sleep = undef,
+) {
+  if $local {
+    # if we're gonna run kadmin.local we better make sure it's
+    # installed
+    include kerberos::server::base
+    $kadmin = "kadmin.local"
+  } else {
+    # if we're gonna run kadmin we better make sure it's installed
+    # and configured
+    include kerberos::client
+    $kadmin = "kadmin"
+
+    $ccache_par = $kadmin_ccache ? {
+      undef => "",
+      default => "-c '$kadmin_ccache'"
+    }
+
+    $keytab_par = $keytab ? {
+      undef => "",
+      default => "-k -t '$keytab'"
+    }
+  }
+
+  $password_par = $password ? {
+    undef => "-nokey",
+    default => "-pw $password"
+  }
+
   exec { "add_principal_$principal_name":
-    command => "kadmin.local -q 'addprinc $flags -pw $password $principal_name'",
-    require => [ Package['krb5-kadmind-server-packages'], Service['krb5-kdc'], ],
+    command => "$kadmin $ccache_par $keytab_par -q 'addprinc $flags $password_par $principal_name'",
+    path => [ "/usr/sbin", "/usr/bin" ],
+    require => $local ? {
+      true => [ Package['krb5-kadmind-server-packages'],
+        Exec['create_krb5kdc_principal'], ],
+      default => [ Package['krb5-client-packages'], File['krb5.conf'] ],
+    },
+    tries => $kadmin_tries,
+    try_sleep => $kadmin_try_sleep,
   }
 }

--- a/manifests/addprinc_keytab_ktadd.pp
+++ b/manifests/addprinc_keytab_ktadd.pp
@@ -1,0 +1,63 @@
+# == Type: kerberos::addprinc_keytab_ktadd
+#
+# Wrapper around addprinc, keytab and ktadd. Uses if defined() to only define
+# resources that aren't defined yet. That way, they can be pre-defined from the
+# outside, forcing e.g. specific permissions.
+#
+# === Authors
+#
+# Michael Weiser <michael.weiser@gmx.de>
+#
+define kerberos::addprinc_keytab_ktadd(
+  $keytab = regsubst($title, "@.*$", ""),
+  $principal = regsubst($title, "^[^@]*@", ""),
+  $local = true, $kadmin_ccache = undef, $kadmin_keytab = undef,
+  $kadmin_tries = undef, $kadmin_try_sleep = undef,
+  # only here for host_keytab - define keytab directly if specific permissions
+  # are desired
+  $keytab_owner = 0, $keytab_group = 0, $keytab_mode = "0400"
+) {
+  if $local == false {
+    include kerberos::host_ticket_cache
+    Kerberos::Ticket_cache["krb5-cache-puppet"] ->
+      Kerberos::Addprinc[$principal]
+  }
+
+  # this is why we can only do one principal at a time - if we ever find a way
+  # to check for multiple resources being defined already, we can enhance this
+  # functions to do multiple principals per keytab in one go.
+  if !defined(Kerberos::Addprinc[$principal]) {
+    kerberos::addprinc { $principal:
+      local => $local,
+      kadmin_ccache => $kadmin_ccache,
+      keytab => $kadmin_keytab,
+      tries => $kadmin_tries,
+      try_sleep => $kadmin_try_sleep,
+    }
+  }
+
+  if !defined(Kerberos::Keytab[$keytab]) {
+    kerberos::keytab { $keytab:
+      owner => $keytab_owner,
+      group => $keytab_group,
+      mode => $keytab_mode,
+    }
+  }
+
+  $ktadd = "$keytab@$principal"
+  if !defined(Kerberos::Ktadd[$ktadd]) {
+    kerberos::ktadd { "$ktadd":
+      keytab => $keytab,
+      principal => $principal,
+      local => $local,
+      kadmin_ccache => $kadmin_ccache,
+      kadmin_keytab => $kadmin_keytab,
+      kadmin_tries => $kadmin_tries,
+      kadmin_try_sleep => $kadmin_try_sleep,
+    }
+  }
+
+  Kerberos::Addprinc[$principal] ->
+    Kerberos::Keytab[$keytab] ->
+    Kerberos::Ktadd["$ktadd"]
+}

--- a/manifests/base.pp
+++ b/manifests/base.pp
@@ -1,12 +1,22 @@
+# == Class: kerberos::base
+#
 # === Authors
 #
 # Author Name <jason@rampaginggeek.com>
+# Additions by Michael Weiser <michael.weiser@gmx.de>
 #
 # === Copyright
 #
 # Copyright 2013 Jason Edgecombe, unless otherwise noted.
 #
-class kerberos::base {
-  include kerberos::params
-
+class kerberos::base (
+  $pkinit_anchors = $kerberos::pkinit_anchors,
+  $pkinit_packages = $kerberos::pkinit_packages,
+) inherits kerberos {
+  if $pkinit_anchors {
+    package { 'krb5-pkinit-packages':
+      ensure => present,
+      name   => $pkinit_packages,
+    }
+  }
 }

--- a/manifests/host_keytab.pp
+++ b/manifests/host_keytab.pp
@@ -1,0 +1,64 @@
+# === Class: kerberos::server::host_keytab
+#
+# Bigtop compatibility
+#
+# === Authors
+#
+# Michael Weiser <michael.weiser@gmx.de>
+#
+define kerberos::host_keytab($princs = [ $title ], $spnego = false,
+  $owner = $title, $group = 0, $mode = "0400",
+  $host_ticket_cache_ccname = $kerberos::host_ticket_cache_ccname,
+) {
+  # hack to get $kerberos::host_ticket_cache_ccname initialised
+  include kerberos
+
+  require stdlib
+  $actual_principals = suffix($princs, "/${fqdn}")
+  $keytab = "/etc/$title.keytab"
+  $ktadds = prefix($actual_principals, "$keytab@")
+  kerberos::addprinc_keytab_ktadd { $ktadds:
+    local => false,
+    keytab_owner => $owner,
+    keytab_group => $group,
+    keytab_mode => $mode,
+    kadmin_ccache => $kerberos::host_ticket_cache_ccname,
+  }
+
+  if $spnego {
+    # workaround for empty princs array
+    if $princs == [] {
+      kerberos::keytab { $keytab:
+        owner => $owner,
+        group => $group,
+        mode => $mode,
+      }
+    }
+
+    # make a separate keytab for HTTP, but only once
+    $keytab_http = "/etc/hadoop-spnego.keytab"
+    $principal_http = "HTTP/${fqdn}"
+    $ktadd_http = "${keytab_http}@${principal_http}"
+    if !defined(Kerberos::Addprinc_keytab_ktadd[$ktadd_http]) {
+      kerberos::addprinc_keytab_ktadd { $ktadd_http:
+        local => false,
+        kadmin_ccache => $kerberos::host_ticket_cache_ccname,
+      }
+    }
+
+    # create the HTTP keytab and then interject the HTTP principal between
+    # keytab creation and first principal addition so that we're finished with
+    # this when the actual addprinc_keytab_ktadd is finished
+    Kerberos::Addprinc_keytab_ktadd[$ktadd_http] ->
+    Kerberos::Keytab[$keytab] ->
+    exec { "krb5-ktutil-${keytab_http}-${keytab}":
+      command => "ktutil <<EOF
+rkt ${keytab_http}
+wkt ${keytab}
+EOF",
+      path => [ "/bin", "/usr/bin" ],
+      unless => "klist -k '${keytab}' | grep ' ${principal_http}@'",
+    } ->
+    Kerberos::Ktadd[$ktadds]
+  }
+}

--- a/manifests/host_ticket_cache.pp
+++ b/manifests/host_ticket_cache.pp
@@ -1,0 +1,26 @@
+# == Class: kerberos::host_ticket_cache
+#
+# Initialise a ticket cache for the host to be used especially by kadmin.
+#
+# === Authors
+#
+# Michael Weiser <michael.weiser@gmx.de>
+#
+
+class kerberos::host_ticket_cache (
+  $host_ticket_cache_ccname = $kerberos::host_ticket_cache_ccname,
+  $host_ticket_cache_service = $kerberos::host_ticket_cache_service,
+  $host_ticket_cache_principal = $kerberos::host_ticket_cache_principal,
+) inherits kerberos {
+  # if this is the KDC, then obviously the machine principals must be
+  # created first
+  Kerberos::Addprinc<| local == true |> ->
+    Kerberos::Ticket_cache["krb5-cache-puppet"]
+
+  kerberos::ticket_cache { "krb5-cache-puppet":
+    ccname    => $host_ticket_cache_ccname,
+    pkinit    => true,
+    principal => $host_ticket_cache_principal,
+    service   => $host_ticket_cache_service,
+  }
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,41 +1,285 @@
 # == Class: kerberos
 #
-# Full description of class kerberos here.
+# Base class for the module. Provides parameter defaulting from
+# kerberos::params with override via hiera lookups.
 #
 # === Parameters
 #
-# Document parameters here.
+# Paths:
 #
-# [*sample_parameter*]
-#   Explanation of what this parameter affects and what it defaults to.
-#   e.g. "Specify one or more upstream ntp servers as an array."
+# $krb5_conf_path:
+#   Path to the client configuration file.
 #
-# === Variables
+# $kdc_conf_path = $kerberos::params::kdc_conf_path,
+#   Path to the main KDC configuration file.
 #
-# Here you should define a list of variables that this module would require.
+# $kadm5_acl_path = $kerberos::params::kadm5_acl_path,
+#   Path to the admin service ACL file.
 #
-# [*sample_variable*]
-#   Explanation of how this variable affects the funtion of this class and if it
-#   has a default. e.g. "The parameter enc_ntp_servers must be set by the
-#   External Node Classifier as a comma separated list of hostnames." (Note,
-#   global variables should not be used in preference to class parameters  as of
-#   Puppet 2.6.)
+# $kpropd_acl_path = $kerberos::params::kpropd_acl_path,
+#   Path to the database replication daemon ACL file.
 #
-# === Examples
+# $kprop_cron_path = $kerberos::params::kprop_cron_path,
+#   Path to the database replication push cron script.
 #
-#  class { kerberos:
-#    servers => [ 'pool.ntp.org', 'ntp.local.company.com' ]
-#  }
+# $kdb5_util_path = $kerberos::params::kdb5_util_path,
+#   Path of kdb5_util used for creating databases.
+#
+# $kprop_path = $kerberos::params::kprop_path,
+#   Path to the kprop utility.
+#
+# Settings in files:
+#
+# krb5.conf
+# $realm:
+#   The Kerberos realm (e.g. 'EXAMPLE.COM')
+#
+# $domain_realm
+#   Hash of domain to realm mappings.
+#
+# $kdcs
+#   Array of KDCs to configure.
+#
+# $master_kdc
+#   The master KDC to configure (used for password changes).
+#
+# $admin_server
+#   The admin service to use.
+#
+# $allow_weak_crypto
+#   Re-enable Single-DES.
+#
+# $forwardable
+#   Request forwardable tickets by default.
+#
+# $proxiable
+#   Request proxiable tickets by default.
+#
+# $pkinit_anchors
+#   Path to CA certificate to use for PKINIT.
+#
+# kdc.conf
+# $kdc_ports
+#   Ports to have the KDC listen on.
+#
+# $kdc_database_path
+#   Path to the principal database.
+#
+# $kdc_stash_path
+#   Path to key stash.
+#
+# $kdc_max_life
+#   Maximum ticket lifetime allowed by the KDC.
+#
+# $kdc_max_renewable_life
+#   Maximum renewable lifetime allowed by the KDC.
+#
+# $kdc_master_key_type
+#   The key type to use to encrypt the principal database.
+#
+# $kdc_supported_enctypes
+#   List of encryption types supported by the KDC.
+#
+# $kdc_pkinit_identity
+#   Certificate and private key to use for PKINIT at the KDC. Format: <path to
+#   cert>,<path to key>. FILE: is prepended automatically if beginning with a
+#   slash.
+#
+# $kdc_logfile
+# no kadm5.conf, so it's in kdc.conf
+# $kadmind_logfile
+#   Valid values for $kdc_logfile and $kadmind_logfile include:
+#   FILE:/var/log/kdc.log
+#   CONSOLE
+#   SYSLOG:INFO:DAEMON
+#   DEVICE=/dev/tty04
+#
+# Yet to try:
+# $kdc_iprop_port
+#   Port to use for incremental replication (listened on by the kpropd on the
+#   slave and connected to by the master?).
+#
+# $kdc_iprop_logfile
+#   Logfile to use for incremental replication (on the master?).
+#
+# $kprop_cron_hour
+# $kprop_cron_minute
+#   When to run the kprop cron job.
+#
+# $kprop_principal
+# $kprop_keytab
+#   Principal and keytab to be used by kprop for authenticating to kpropd on
+#   the slave.
+#
+# $kpropd_iprop_resync_timeout
+#   ?
+#
+# $kpropd_principal
+# $kpropd_keytab
+#   What principal and keytab kpropd should authentication for and verify it
+#   with.
+#
+# $kpropd_master_principal
+#   What principals to allow to update the database on this slave.
+#
+# $kdc_principals
+# $kdc_trusted_realms
+#   Principals and realm trusts to be created on the master.
+#
+# $kadmind_enable
+#   Whether to actually enable kadmind.
+#
+# $kadmind_acls
+#   ACLs for for the admin service.
+#
+# $kdc_slaves
+#   List of slaves of this KDC (may be a slave itself).
+#
+# $host_ticket_cache_ccname
+# $host_ticket_cache_service
+# $host_ticket_cache_principal
+#   When creating a ticket cache for use by kadmin use these parameters.
+#
+# $pkinit_packages
+# $client_packages
+# $kdc_server_packages
+# $kadmin_server_packages
+# $kpropd_server_packages
+#   Package names.
+#
+# $kdc_service_name
+# $kadmin_service_name
+# $kpropd_service_name
+#   Service names.
+#
+# === References
+#
+# [1] http://web.mit.edu/kerberos/krb5-1.6/krb5-1.6.3/doc/krb5-install.html#Create-the-Database
+#
+# [2] http://web.mit.edu/kerberos/krb5-1.6/krb5-1.6.3/doc/krb5-install.html#Add-Administrators-to-the-Acl-File
+#
+# [3] http://web.mit.edu/kerberos/krb5-1.6/krb5-1.6.3/doc/krb5-install.html#Create-a-kadmind-Keytab-_0028optional_0029
 #
 # === Authors
 #
 # Author Name <jason@rampaginggeek.com>
+# Additions by Michael Weiser <michael.weiser@gmx.de>
 #
 # === Copyright
 #
 # Copyright 2013 Jason Edgecombe, unless otherwise noted.
 #
-class kerberos {
+class kerberos(
+  # roles
+  $client = false,
+  $master = false,
+  $slave = false,
 
+  # paths to configuration files
+  $krb5_conf_path = $kerberos::params::krb5_conf_path,
+  $kdc_conf_path = $kerberos::params::kdc_conf_path,
+  $kadm5_acl_path = $kerberos::params::kadm5_acl_path,
+  $kpropd_acl_path = $kerberos::params::kpropd_acl_path,
+  $kprop_cron_path = $kerberos::params::kprop_cron_path,
+  $kdb5_util_path = $kerberos::params::kdb5_util_path,
+  $kprop_path = $kerberos::params::kprop_path,
 
+  # settings in files
+  $realm = 'EXAMPLE.COM',
+  $domain_realm = {},
+  $kdcs = [],
+  $master_kdc = undef,
+  $admin_server = undef,
+  $allow_weak_crypto = false,
+  $forwardable = true,
+  $proxiable = true,
+  $pkinit_anchors = undef,
+
+  $kdc_ports = '88',
+  $kdc_database_path = $kerberos::params::kdc_database_path,
+  $kdc_database_password = undef,
+  $kdc_stash_path = $kerberos::params::kdc_stash_path,
+  $kdc_max_life = '10h 0m 0s',
+  $kdc_max_renewable_life = '7d 0h 0m 0s',
+  $kdc_master_key_type = 'aes256-cts',
+  $kdc_supported_enctypes = ['aes256-cts:normal', 'arcfour-hmac:normal', 'des3-hmac-sha1:normal' ],
+  $kdc_pkinit_identity = undef,
+  $kdc_logfile = $kerberos::params::kdc_logfile,
+  $kdc_iprop_port = undef,
+  $kdc_iprop_logfile = undef,
+
+  # no kadm5.conf, so it's in kdc.conf
+  $kadmind_logfile = $kerberos::params::kadmind_logfile,
+
+  $kprop_cron_hour = '*',
+  $kprop_cron_minute = '*/5',
+  $kprop_principal = "host/$fqdn",
+  $kprop_keytab = "/etc/krb5.keytab",
+
+  $kpropd_iprop_resync_timeout = undef,
+  $kpropd_principal = "host/$fqdn",
+  $kpropd_keytab = "/etc/krb5.keytab",
+  $kpropd_master_principal = undef,
+
+  # settings to be implemented via logic
+  $kdc_principals = {},
+  $kdc_trusted_realms = {},
+
+  $kadmind_enable = true,
+  $kadmind_acls = { "*/admin@$realm" => '*' },
+
+  $kdc_slaves = undef,
+
+  $host_ticket_cache_ccname = "/tmp/krb5cc.puppet",
+  $host_ticket_cache_service = "kadmin/admin",
+  $host_ticket_cache_principal = $fqdn,
+
+  # packages
+  $pkinit_packages = $kerberos::params::pkinit_packages,
+  $client_packages = $kerberos::params::client_packages,
+  $kdc_server_packages = $kerberos::params::kdc_server_packages,
+  $kadmin_server_packages = $kerberos::params::kadmin_server_packages,
+  $kpropd_server_packages = $kerberos::params::kpropd_server_packages,
+
+  # service names
+  $kdc_service_name = $kerberos::params::kdc_service_name,
+  $kadmin_service_name = $kerberos::params::kadmin_service_name,
+  $kpropd_service_name = $kerberos::params::kpropd_service_name,
+) inherits kerberos::params {
+  $kpropd_master_principal_cfg = $kpropd_master_principal ? {
+    default => $kpropd_master_principal,
+    undef => "host/$master_kdc@$realm",
+  }
+
+  $kdc_logfile_cfg = $kdc_logfile ? {
+    undef => undef,
+    default => regsubst($kdc_logfile, "^/", "FILE:/")
+  }
+
+  $kadmind_logfile_cfg = $kadmind_logfile ? {
+    undef => undef,
+    default => regsubst($kadmind_logfile, "^/", "FILE:/")
+  }
+
+  $pkinit_anchors_cfg = $pkinit_anchors ? {
+    undef => undef,
+    default => regsubst($pkinit_anchors, "^/", "FILE:/")
+  }
+
+  $kdc_pkinit_identity_cfg = $kdc_pkinit_identity ? {
+    undef => undef,
+    default => regsubst($kdc_pkinit_identity, "^/", "FILE:/")
+  }
+
+  if $client {
+    include kerberos::client
+  }
+
+  if $master {
+    include kerberos::kdc::master
+  }
+
+  if $slave {
+    include kerberos::kdc::slave
+  }
 }

--- a/manifests/kdc/master.pp
+++ b/manifests/kdc/master.pp
@@ -1,0 +1,78 @@
+# === Class: kerberos::kdc::master
+#
+# Kerberos master kdc: Sets up the server daemons using kerberos::server::kdc
+# and kerberos::server::kadmind classes. Creates the master database and adds a
+# cron job for updating the slaves.
+#
+# === Authors
+#
+# Jason Edgecombe <jason@rampaginggeek.com>
+#
+# Additions by <greg.1.anderson@greeknowe.org>
+# Additions by Michael Weiser <michael.weiser@gmx.de>
+#
+# === Copyright
+#
+# Copyright 2013 Jason Edgecombe, unless otherwise noted.
+#
+class kerberos::kdc::master (
+  $kadmind_enable = $kerberos::kadmind_enable,
+  $kdc_slaves = $kerberos::kdc_slaves,
+  $kdc_database_password = $kerberos::kdc_database_password,
+  $kdc_principals = $kerberos::kdc_principals,
+  $kdc_trusted_realms = $kerberos::kdc_trusted_realms,
+
+  $kdb5_util_path = $kerberos::kdb5_util_path,
+) inherits kerberos {
+  # at a minimum a master has a krb5kdc server
+  include kerberos::server::kdc
+
+  # convenience setting for enabling and disabling kadmind
+  if $kadmind_enable {
+    include kerberos::server::kadmind
+  }
+
+  # set up kprop cron job if we have slaves
+  if $kdc_slaves {
+    include kerberos::server::kprop
+  }
+
+  if $kdc_database_password {
+    $db_password = $kdc_database_password
+  } else {
+    $db_password = trocla("kdc_database_password", "plain")
+  }
+
+  exec { "create_krb5kdc_principal":
+    command => "$kdb5_util_path -r $realm -P \'$db_password\' create -s",
+    creates => "$kdc_database_path",
+    require => [ File['krb5-kdc-database-dir', 'kdc.conf'], ],
+  }
+
+  # Look up our users in hiera. Create a principal for each one listed
+  # for this realm.
+  $kerberos_principals = hiera_hash("kerberos::principals", $kdc_principals)
+  create_resources('kerberos::addprinc', $kerberos_principals)
+
+  # KDC database must be created before we can start the KDC service and it
+  # should be restarted if someone deleted its database from underneath it
+  Exec['create_krb5kdc_principal'] ~> Service['krb5kdc']
+
+  # KDC database must be created before *any* principals can be added - duh
+  Exec['create_krb5kdc_principal'] -> Kerberos::Addprinc<||>
+
+  # all principal-adding using kadmin.local should be done before we
+  # start the KDC
+  Kerberos::Addprinc<| local == true |> -> Service['krb5kdc']
+
+  # Look up our trusted realms from hiera. Create trusted principal pairs
+  # for each trusted realm that is not the realm of the current server.
+  $trusts = hiera_hash('kerberos::trusted_realms', $trusted_realms)
+  if $trusts {
+    $trusted_realms = delete($trusts['realms'], $realm)
+    kerberos::trust { $trusts:
+      this_realm => $realm,
+      password   => $trusts['password'],
+    }
+  }
+}

--- a/manifests/kdc/slave.pp
+++ b/manifests/kdc/slave.pp
@@ -1,0 +1,54 @@
+# === Class: kerberos::kdc::slave
+#
+# Kerberos slave KDC: Sets up the server daemons using kerberos::server::kdc
+# and kerberos::server::kpropd classes.
+#
+# === Authors
+#
+# Jason Edgecombe <jason@rampaginggeek.com>
+#
+# Additions by <greg.1.anderson@greeknowe.org>
+# Additions by Michael Weiser <michael.weiser@gmx.de>
+#
+# === Copyright
+#
+# Copyright 2013 Jason Edgecombe, unless otherwise noted.
+#
+class kerberos::kdc::slave (
+  $kdc_slaves = $kerberos::kdc_slaves,
+  $kdc_database_path = $kerberos::kdc_database_path,
+  $kdc_database_password = $kerberos::kdc_database_password,
+  $kdc_stash_path = $kerberos::kdc_stash_path,
+) inherits kerberos {
+  # at a minimum a slave has krb5kdc and kpropd server
+  include kerberos::server::kdc
+  include kerberos::server::kpropd
+
+  # set up kprop cron job if we have slaves
+  if $kdc_slaves {
+    include kerberos::server::kprop
+  }
+
+  if $kdc_database_password {
+    $db_password = $kdc_database_password
+  } else {
+    $db_password = trocla("kdc_database_password", "plain")
+  }
+
+  # funky: Wait for someone to create our database before starting the KDC. In
+  # this case that someone is kpropd. Should only ever cause a real wait if
+  # we're bootstrapping and the database doesn't exist yet.
+  Service['kpropd'] ->
+  exec { "krb5-wait-for-database":
+    command   => "test -f '$kdc_database_path'",
+    path      => [ "/bin", "/usr/bin" ],
+    tries     => 10,
+    try_sleep => 30,
+  } ->
+  exec { "krb5-stash-database-pw":
+    command => "echo '${db_password}' | kdb5_util stash",
+    path => [ "/bin", "/usr/bin", "/sbin", "/usr/sbin" ],
+    creates => $kdc_stash_path,
+  } ~>
+  Service['krb5kdc']
+}

--- a/manifests/keytab.pp
+++ b/manifests/keytab.pp
@@ -1,0 +1,26 @@
+# === Type: kerberos::keytab
+#
+# Creates an empty (!) keytab for later addition of keys using kerberos::ktadd.
+# Can force specific owner, group and mode on the file.
+#
+# === Authors
+#
+# Michael Weiser <michael.weiser@gmx.de>
+#
+
+define kerberos::keytab($keytab = $title,
+  $mode = "0400", $owner = 0, $group = 0,
+  $replace = false,
+) {
+  # TODO: Avoid recreation if already existing but do update if keys get to
+  # old...
+  file { $keytab:
+    ensure => file,
+    replace => $replace,
+    backup => false,
+    content => inline_template('<%= "\x05\x02" %>'),
+    owner => $owner,
+    group => $group,
+    mode => $mode,
+  }
+}

--- a/manifests/ktadd.pp
+++ b/manifests/ktadd.pp
@@ -1,0 +1,55 @@
+# === Type: kerberos::ktadd
+#
+# Adds a kerberos key to a keytab. Supports use of kadmin.local or kadmin. The
+# latter supports use of a ticket cache or a keytab file.
+#
+# === Authors
+#
+# Michael Weiser <michael.weiser@gmx.de>
+#
+
+# infer principal and keytab file names from title if not given explicitly,
+# syntax: <keytab>@<principal_possibly_containing_more_@s>
+define kerberos::ktadd(
+  $keytab = regsubst($title, "@.*$", ""),
+  $principal = regsubst($title, "^[^@]*@", ""),
+  $local = true, $reexport = false,
+  $kadmin_ccache = undef, $kadmin_keytab = undef,
+  $kadmin_tries = undef, $kadmin_try_sleep = undef,
+) {
+  if $local {
+    $kadmin = "kadmin.local"
+    Package['krb5-kadmind-server-packages'] -> Exec["ktadd_${keytab}_${principal}"]
+    Exec['create_krb5kdc_principal'] -> Exec["ktadd_${keytab}_${principal}"]
+  } else {
+    $kadmin = "kadmin"
+
+    $ccache_par = $kadmin_ccache ? {
+      undef   => "",
+      default => "-c '$kadmin_ccache'"
+    }
+
+    $keytab_par = $kadmin_keytab ? {
+      undef   => "",
+      default => "-k '$kadmin_keytab'"
+    }
+
+    Package['krb5-client-packages'] -> Exec["ktadd_${keytab}_${principal}"]
+    File['krb5.conf'] -> Exec["ktadd_${keytab}_${principal}"]
+  }
+
+  if $reexport {
+    $unless = undef
+  } else {
+    $unless = "klist -k '${keytab}' | grep ' ${principal}@'"
+  }
+
+  exec { "ktadd_${keytab}_${principal}":
+    command => "$kadmin $ccache_par $keytab_par -q 'ktadd -k $keytab $principal'",
+    unless  => $unless,
+    path    => [ "/bin", "/usr/bin", "/usr/bin", "/usr/sbin" ],
+    require => File[$keytab],
+    tries => $kadmin_tries,
+    try_sleep => $kadmin_try_sleep,
+  }
+}

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,24 +1,41 @@
+# == Class: kerberos::params
+#
+# Provides platform-dependant default values for certain parameters of the main
+# kerberos class.
+#
 # === Authors
 #
 # Jason Edgecombe <jason@rampaginggeek.com>
+# Additions by Michael Weiser <michael.weiser@gmx.de>
 #
 # === Copyright
 #
 # Copyright 2013 Jason Edgecombe, unless otherwise noted.
 #
 class kerberos::params {
-
   case $::operatingsystem {
-    Ubuntu: {
+    Ubuntu, Debian: {
       $client_packages    = [ 'krb5-user' ]
       $kdc_server_packages    = [ 'krb5-kdc' ]
       $kadmin_server_packages = [ 'krb5-admin-server' ]
+      $pkinit_packages        = [ 'krb5-pkinit' ]
+
+      $kdc_service_name       = 'krb5-kdc'
+      $kadmin_service_name    = 'krb5-admin-server'
+      $kpropd_service_name    = 'krb5-kpropd'
+
       $krb5_conf_path         = '/etc/krb5.conf'
       $kdc_conf_path          = '/etc/krb5kdc/kdc.conf'
       $kadm5_acl_path         = '/etc/krb5kdc/kadm5.acl'
-      $krb5kdc_database_path  = '/var/lib/krb5kdc/principal'
-      $admin_keytab_path      = '/etc/krb5kdc/kadm5.keytab'
-      $key_stash_path         = '/etc/krb5kdc/stash'
+      $kpropd_acl_path        = '/etc/krb5kdc/kpropd.acl'
+      $kprop_cron_path        = '/etc/krb5kdc/kprop.cron'
+      $kprop_path             = '/usr/sbin/kprop'
+      $kdb5_util_path         = '/usr/sbin/kdb5_util'
+
+      $kdc_database_path      = '/var/lib/krb5kdc/principal'
+      $kdc_stash_path         = '/etc/krb5kdc/stash'
+      $kdc_logfile            = '/var/log/kdc.log'
+      $kadmind_logfile        = '/var/log/kerberos_admin_server.log'
     }
     default: {
       fail("The ${module_name} module is not supported on ${::osfamily} based systems")

--- a/manifests/server/base.pp
+++ b/manifests/server/base.pp
@@ -1,0 +1,47 @@
+# === Class: kerberos::server::base
+#
+# Kerberos KDC base elements: Generates kdc.conf needed by kdc and kadmind.
+#
+# === Authors
+#
+# Author Name <jason@rampaginggeek.com>
+#
+# Additions by <greg.1.anderson@greeknowe.org>
+# Additions by Michael Weiser <michael.weiser@gmx.de>
+#
+# === Copyright
+#
+# Copyright 2013 Jason Edgecombe, unless otherwise noted.
+#
+class kerberos::server::base (
+  $kdc_conf_path = $kerberos::kdc_conf_path,
+
+  $realm = $kerberos::realm,
+  $kdc_ports = $kerberos::kdc_ports,
+  $kdc_database_path = $kerberos::kdc_database_path,
+  $kdc_stash_path = $kerberos::kdc_stash_path,
+  $kdc_max_life = $kerberos::kdc_max_life,
+  $kdc_max_renewable_life = $kerberos::kdc_max_renewable_life,
+  $kdc_master_key_type = $kerberos::kdc_master_key_type,
+  $kdc_supported_enctypes = $kerberos::kdc_supported_enctypes,
+  $pkinit_anchors = $kerberos::pkinit_anchors_cfg,
+  $kdc_pkinit_identity = $kerberos::kdc_pkinit_identity_cfg,
+  $kdc_logfile = $kerberos::kdc_logfile_cfg,
+  $kadmind_logfile = $kerberos::kadmind_logfile_cfg,
+) inherits kerberos {
+  require stdlib
+  $kdc_conf_dir = dirname($kdc_conf_path)
+  if !defined(File[$kdc_conf_dir]) {
+    file { $kdc_conf_dir: ensure => "directory" }
+  }
+
+  file { 'kdc.conf':
+    ensure  => file,
+    path    => $kdc_conf_path,
+    content => template('kerberos/kdc.conf.erb'),
+    mode    => '0644',
+    owner   => 0,
+    group   => 0,
+    require => File[$kdc_conf_dir],
+  }
+}

--- a/manifests/server/kadmind.pp
+++ b/manifests/server/kadmind.pp
@@ -1,24 +1,52 @@
+# === Class: kerberos::server::kdc
+#
+# Kerberos admin service. Installs and starts the kadmin service. Does not
+# create the master KDC database though. Use kerberos::kdc::master to set up
+# functioning KDCs.
+#
 # === Authors
 #
 # Author Name <jason@rampaginggeek.com>
+# Additions by Michael Weiser <michael.weiser@gmx.de>
 #
 # === Copyright
 #
 # Copyright 2013 Jason Edgecombe, unless otherwise noted.
 #
-class kerberos::server::kadmind {
-  include kerberos::base
+class kerberos::server::kadmind (
+  $kadm5_acl_path = $kerberos::kadm5_acl_path,
+  $kadmind_acls = $kerberos::kadmind_acls,
+  $kadmin_service_name = $kerberos::kadmin_service_name,
+) inherits kerberos {
+  include kerberos::server::kadmind_kprop
 
-  package { 'krb5-kadmind-server-packages' :
-    ensure => present,
-    name   => $kerberos::params::kadmin_server_packages,
+  require stdlib
+  $kadm5_acl_dir = dirname($kadm5_acl_path)
+  if !defined(File[$kadm5_acl_dir]) {
+    file { $kadm5_acl_dir: ensure => "directory" }
   }
 
-  service { 'krb5-admin-server':
+  file { 'kadm5.acl':
+    ensure  => file,
+    path    => $kadm5_acl_path,
+    content => template('kerberos/kadm5.acl.erb'),
+    mode    => '0644',
+    owner   => 0,
+    group   => 0,
+    require => File[$kadm5_acl_dir],
+  }
+
+  service { 'kadmind':
+    name       => $kadmin_service_name,
     ensure     => running,
     enable     => true,
     hasrestart => true,
     hasstatus  => true,
-    subscribe  => File['krb5.conf'],
+    require    => Exec["create_krb5kdc_principal"],
+    subscribe  => [ File['kdc.conf', 'kadm5.acl'], Exec['create_krb5kdc_principal'] ],
   }
+
+  # all adding of principals using kadmin can only be done after kadmind
+  # is started
+  Service['kadmind'] -> Kerberos::Addprinc<| local == false |>
 }

--- a/manifests/server/kadmind_kprop.pp
+++ b/manifests/server/kadmind_kprop.pp
@@ -1,0 +1,28 @@
+# === Class: kerberos::server::kadmind_kprop
+#
+# Kerberos KDC kadmin and kpropd common elements: Installs kadmind packages
+# which also contain kprop.
+#
+# === Authors
+#
+# Author Name <jason@rampaginggeek.com>
+#
+# Additions by <greg.1.anderson@greeknowe.org>
+# Additions by Michael Weiser <michael.weiser@gmx.de>
+#
+# === Copyright
+#
+# Copyright 2013 Jason Edgecombe, unless otherwise noted.
+#
+class kerberos::server::kadmind_kprop (
+  $kadmin_server_packages = $kerberos::kadmin_server_packages,
+) inherits kerberos {
+  # kadmind and kprop both only make sense on a master KDC. So pull in
+  # general common server config for KDCs.
+  include kerberos::server::base
+
+  package { 'krb5-kadmind-server-packages':
+    ensure => present,
+    name   => $kadmin_server_packages,
+  }
+}

--- a/manifests/server/kdc.pp
+++ b/manifests/server/kdc.pp
@@ -1,126 +1,64 @@
 # === Class: kerberos::server::kdc
 #
-# Kerberos kdc configuration file definition.  Configures your
-# kdc, including the kdc.conf file and Kerberos principals.
-#
-# === Parameters
-#
-#   $realm:
-#     The Kerberos realm (e.g. 'EXAMPLE.COM')
-#   $master_password:
-#     The master password for the kdc database. [1]
-#   $acl:
-#     Access control list entries. [2]
-#   $kdc_conf_path:
-#     Path to kdc.conf.  See: templates/kdc.conf.erb
-#   $kadm5_acl_path:
-#     Path to kadm5.acl.  See: templates/kadm5.acl
-#   $krb5kdc_database_path:
-#     Path to kdc principals database.
-#   $admin_keytab_path:
-#     Path to admin keytab. [3]
-#   $key_stash_path:
-#     Path to key stash.
-#
-# === References
-#
-# [1] http://web.mit.edu/kerberos/krb5-1.6/krb5-1.6.3/doc/krb5-install.html#Create-the-Database
-#
-# [2] http://web.mit.edu/kerberos/krb5-1.6/krb5-1.6.3/doc/krb5-install.html#Add-Administrators-to-the-Acl-File
-#
-# [3] http://web.mit.edu/kerberos/krb5-1.6/krb5-1.6.3/doc/krb5-install.html#Create-a-kadmind-Keytab-_0028optional_0029
-#
-# === Sample Usage
-#
-#     class {'kerberos::server::kdc':
-#       realm => "REALMONE.LOCAL",
-#     }
-#
-#   It is best to store passwords in Hiera; see README file for details.
+# Kerberos kdc service. Installs and starts the KDC service. Uses
+# kerberos::server::base to create kdc.conf. Although it starts the service
+# it does not create a database. Use kerberos::kdc::master or
+# kerberos::kdc:slave to actually set up functioning KDCs.
 #
 # === Authors
 #
 # Author Name <jason@rampaginggeek.com>
 #
 # Additions by <greg.1.anderson@greeknowe.org>
+# Additions by Michael Weiser <michael.weiser@gmx.de>
 #
 # === Copyright
 #
 # Copyright 2013 Jason Edgecombe, unless otherwise noted.
 #
-class kerberos::server::kdc(
-  $realm = 'EXAMPLE.COM',
-  $master_password,
-  $acl = { "*/admin@$realm" => '*' },
-  $kdc_conf_path = $kerberos::params::kdc_conf_path,
-  $kadm5_acl_path = $kerberos::params::kadm5_acl_path,
-  $krb5kdc_database_path = $kerberos::params::krb5kdc_database_path,
-  $admin_keytab_path = $kerberos::params::admin_keytab_path,
-  $key_stash_path = $kerberos::params::key_stash_path,
-) inherits kerberos::base {
+class kerberos::server::kdc (
+  $kdc_database_path = $kerberos::kdc_database_path,
+  $kdc_server_packages = $kerberos::kdc_server_packages,
+  $kdc_service_name = $kerberos::kdc_service_name,
+) inherits kerberos {
+  # pkinit packages
   include kerberos::base
+  # kdc.conf
+  include kerberos::server::base
 
   package { 'krb5-kdc-server-packages' :
     ensure => present,
-    name   => $kerberos::params::kdc_server_packages,
+    name   => $kdc_server_packages,
     before => File['kdc.conf'],
   }
 
-  file { 'kdc.conf':
-    ensure  => file,
-    path    => $kdc_conf_path,
-    content => template('kerberos/kdc.conf.erb'),
-    mode    => '0644',
-    owner   => 0,
-    group   => 0,
-  }
-
-  file { "/etc/krb5kdc":
-    ensure => "directory",
-  }
-
-  file { 'kadm5.acl':
-    ensure  => file,
-    path    => $kadm5_acl_path,
-    content => template('kerberos/kadm5.acl.erb'),
-    mode    => '0644',
-    owner   => 0,
-    group   => 0,
-    require => File['/etc/krb5kdc'],
-  }
-
-  file { "/var/lib/krb5kdc":
-    ensure => "directory",
-  }
-
-  exec { "create_krb5kdc_principal":
-    command => "/usr/sbin/kdb5_util -r $realm -P $master_password create -s",
-    creates => "$krb5kdc_database_path",
-    require => [ File['/var/lib/krb5kdc'], File['krb5.conf'], File['kdc.conf'], Exec["initialize_dev_random"], ],
-  }
-
-  # Look up our users in hiera.  Create a principal for each one listed
-  # for this realm.
-  $kerberos_principals = hiera("kerberos_principals", [])
-  create_resources('kerberos::addprinc',$kerberos_principals)
-
-  # Look up our trusted realms from hiera.  Create trusted principal pairs
-  # for each trusted realm that is not the realm of the current server.
-  $trusted = hiera('trusted_realms', [])
-  $trusted_realms = delete($trusted['realms'], $realm)
-  if $trusted {
-    kerberos::trust { $trusted_realms:
-      this_realm => $realm,
-      password => $trusted['password'],
+  # is created here for both master and slave
+  require stdlib
+  $kdc_database_dir = dirname($kdc_database_path)
+  if !defined(File[$kdc_database_dir]) {
+    # title used by master.pp to require dir before creating
+    # database
+    file { "krb5-kdc-database-dir":
+      path   => $kdc_database_dir,
+      ensure => "directory",
+      mode   => "0700",
     }
   }
 
-  service { 'krb5-kdc':
+  service { 'krb5kdc':
+    name       => $kdc_service_name,
     ensure     => running,
     enable     => true,
     hasrestart => true,
     hasstatus  => true,
+    require    => File[$kdc_database_dir],
     subscribe  => File['kdc.conf'],
-    require => Exec["create_krb5kdc_principal"],
   }
+
+  # all adding of principals using kadmin.local should be done before the
+  # KDC is started
+  Kerberos::Addprinc<| local == true |> -> Service['krb5kdc']
+
+  # installed in kerberos::base if enabled
+  Package<| title == 'krb5-pkinit-packages' |> -> Service['krb5kdc']
 }

--- a/manifests/server/kprop.pp
+++ b/manifests/server/kprop.pp
@@ -1,0 +1,81 @@
+# === Class: kerberos::server::kprop
+#
+# Kerberos kprop program: Adds a cron job for updating the slave servers.
+#
+# === Authors
+#
+# Jason Edgecombe <jason@rampaginggeek.com>
+#
+# Additions by <greg.1.anderson@greeknowe.org>
+# Additions by Michael Weiser <michael.weiser@gmx.de>
+#
+# === Copyright
+#
+# Copyright 2013 Jason Edgecombe, unless otherwise noted.
+#
+class kerberos::server::kprop (
+  $kprop_cron_path = $kerberos::kprop_cron_path,
+  $kprop_cron_hour = $kprop_cron_hour,
+  $kprop_cron_minute = $kerberos::kprop_cron_minute,
+  $kprop_keytab = $kerberos::kprop_keytab,
+  $kprop_principal = $kerberos::kprop_principal,
+
+  $kdc_slaves = $kerberos::kdc_slaves,
+  $kdc_database_path = $kerberos::kdc_database_path,
+  $kprop_path = $kerberos::kprop_path,
+  $kdb5_util_path = $kerberos::kdb5_util_path,
+
+  $pkinit_anchors = $kerberos::pkinit_anchors,
+  $host_ticket_cache_ccname = $kerberos::host_ticket_cache_ccname,
+
+  # facter fact
+  $kerberos_bootstrap = $::kerberos_bootstrap,
+) inherits kerberos {
+  include kerberos::server::kadmind_kprop
+
+  # if we have pkinit we can automatically create the keytab for kprop
+  $ktadd = "$kprop_keytab@$kprop_principal"
+  if $pkinit_anchors and !defined(Kerberos::Addprinc_keytab_ktadd["$ktadd"]) {
+    kerberos::addprinc_keytab_ktadd { "$ktadd":
+      local => false,
+      kadmin_ccache => $host_ticket_cache_ccname,
+    } -> Cron['kprop']
+  }
+
+  require stdlib
+  # needed in the kprop template
+  $kdc_database_dir = dirname($kdc_database_path)
+
+  $kprop_cron_dir = dirname($kprop_cron_path)
+  if !defined(File[$kprop_cron_dir]) {
+    file { $kprop_cron_dir: ensure => "directory" }
+  }
+
+  file { 'kprop.cron':
+    ensure  => file,
+    path    => $kprop_cron_path,
+    content => template('kerberos/kprop.cron.erb'),
+    mode    => '0755',
+    owner   => 0,
+    group   => 0,
+    require => File[$kprop_cron_dir],
+  }
+
+  cron { 'kprop':
+    command => $kprop_cron_path,
+    user    => 'root',
+    hour    => $kprop_cron_hour,
+    minute  => $kprop_cron_minute,
+  }
+
+  if $kerberos_bootstrap {
+    exec { 'kprop-force':
+      command   => $kprop_cron_path,
+      user      => 'root',
+      tries     => 30,
+      try_sleep => 10,
+      # you can't do a bootstrap without a keytab for kprop
+      require   => Kerberos::Ktadd["$ktadd"]
+    }
+  }
+}

--- a/manifests/server/kpropd.pp
+++ b/manifests/server/kpropd.pp
@@ -1,0 +1,61 @@
+# === Class: kerberos::server::kdc
+#
+# Kerberos kpropd service. Installs and starts the kpropd service on a slave KDC.
+#
+# === Authors
+#
+# Author Name <jason@rampaginggeek.com>
+# Additions by Michael Weiser <michael.weiser@gmx.de>
+#
+# === Copyright
+#
+# Copyright 2013 Jason Edgecombe, unless otherwise noted.
+#
+class kerberos::server::kpropd (
+  $kpropd_acl_path = $kerberos::kpropd_acl_path,
+  $kpropd_master_principal = $kerberos::kpropd_master_principal_cfg,
+  $kpropd_service_name = $kerberos::kpropd_service_name,
+  $kpropd_keytab = $kerberos::kpropd_keytab,
+  $kpropd_principal = $kerberos::kpropd_principal,
+
+  $pkinit_anchors = $kerberos::pkinit_anchors,
+  $host_ticket_cache_ccname = $kerberos::host_ticket_cache_ccname,
+
+  # facter fact
+  $kerberos_bootstrap = $::kerberos_bootstrap,
+) inherits kerberos::params {
+  include kerberos::server::kdc
+
+  # if we have pkinit we can automatically create the keytab
+  $ktadd = "$kpropd_keytab@$kpropd_principal"
+  if $pkinit_anchors and !defined(Kerberos::Addprinc_keytab_ktadd["$ktdadd"]) {
+    kerberos::addprinc_keytab_ktadd { "$ktadd":
+      local => false,
+      kadmin_ccache => $host_ticket_cache_ccname,
+      # if we're bootstrapping the master might not be up yet and even if not
+      # it might just be rebooting
+      kadmin_tries => 30,
+      kadmin_try_sleep => $kerberos_bootstrap ? { '1' => 60, default => 10 },
+    } -> Service['kpropd']
+  }
+
+  file { 'kpropd.acl':
+    ensure  => file,
+    path    => $kpropd_acl_path,
+    content => template('kerberos/kpropd.acl.erb'),
+    mode    => '0600',
+    owner   => 0,
+    group   => 0,
+  }
+
+  service { 'kpropd':
+    name       => $kpropd_service_name,
+    ensure     => running,
+    enable     => true,
+    hasrestart => true,
+    hasstatus  => true,
+    subscribe  => File['kdc.conf', 'kpropd.acl', $kpropd_keytab],
+    # kpropd needs its keytab to work
+    require    => Kerberos::Ktadd["$ktadd"]
+  }
+}

--- a/manifests/ticket_cache.pp
+++ b/manifests/ticket_cache.pp
@@ -1,0 +1,43 @@
+# === Type: kerberos::ticket_cache
+#
+# Requests a TGT and puts it in a ticket cache. Supports use of a keytab file
+# or PKINIT.
+#
+# === Authors
+#
+# Michael Weiser <michael.weiser@gmx.de>
+#
+define kerberos::ticket_cache ($ccname = $title,
+    $principal = "",
+    $keytab = undef,
+    $service = undef,
+    $pkinit = false,
+    $pkinit_cert = "/var/lib/puppet/ssl/certs/${fqdn}.pem",
+    $pkinit_key = "/var/lib/puppet/ssl/private_keys/${fqdn}.pem") {
+  # this needs to be a client in order to run kinit and kadmin
+  include kerberos::client
+
+  $kinit = "kinit"
+  $keytab_par = $keytab ? {
+    undef   => "",
+    default => " -k -t '$keytab'"
+  }
+
+  $pkinit_par = $pkinit ? {
+    undef   => "",
+    default => " -X 'X509_user_identity=FILE:${pkinit_cert},${pkinit_key}'"
+  }
+
+  $service_par = $service ? {
+    undef   => "",
+    default => "-S '$service'"
+  }
+
+  exec { "ticket_cache_$title":
+    command => "kinit -c '$ccname' $keytab_par $pkinit_par $service_par $principal",
+    path    => "/usr/bin",
+    require => [ Package['krb5-client-packages'], File['krb5.conf'] ],
+    # always recreate (for now) to avoid expired tickets
+    # creates => $ccname
+  }
+}

--- a/manifests/trust.pp
+++ b/manifests/trust.pp
@@ -1,3 +1,8 @@
+# == Type: kerberos::trust
+#
+# Creates a trust between two realms *on this KDC*. Needs to be done on both
+# KDCs.
+#
 # To make this realm, $::realm trust realms EXAMPLE.COM and EXAMPLE.ORG:
 #
 # kerberos::trust { [ "EXAMPLE.COM", "EXAMPLE.ORG" ]:
@@ -16,11 +21,12 @@
 #
 # Copyright 2014 Jason Edgecombe (Copyright assigned by original author)
 #
-define kerberos::trust($trusted_realm = $title, $this_realm, $password = 'password') {
+define kerberos::trust($trusted_realm = $title, $this_realm, $password) {
   kerberos::addprinc { "krbtgt/$this_realm@$trusted_realm":
     password => $password,
     flags => "-requires_preauth",
   }
+
   kerberos::addprinc { "krbtgt/$trusted_realm@$this_realm":
     password => $password,
     flags => "-requires_preauth",

--- a/templates/kadm5.acl.erb
+++ b/templates/kadm5.acl.erb
@@ -1,3 +1,3 @@
-<% acl.each_pair do |principal, val| -%>
+<% @kadmind_acls.each_pair do |principal, val| -%>
 <%= principal %> <%= val %>
 <% end -%>

--- a/templates/kdc.conf.erb
+++ b/templates/kdc.conf.erb
@@ -1,16 +1,37 @@
 [kdcdefaults]
-    kdc_ports = 750,88
+    kdc_ports = <%= @kdc_ports %>
 
 [realms]
     <%= @realm %> = {
-        database_name = <%= @krb5kdc_database_path %>
-        admin_keytab = FILE:<%= @admin_keytab_path %>
+        database_name = <%= @kdc_database_path %>
         acl_file = <%= @kadm5_acl_path %>
-        key_stash_file = <%= @key_stash_path %>
-        kdc_ports = 750,88
-        max_life = 10h 0m 0s
-        max_renewable_life = 7d 0h 0m 0s
-        master_key_type = des3-hmac-sha1
-        supported_enctypes = aes256-cts:normal arcfour-hmac:normal des3-hmac-sha1:normal des-cbc-crc:normal des:normal des:v4 des:norealm des:onlyrealm des:afs3
+        key_stash_file = <%= @kdc_stash_path %>
+        max_life = <%= @kdc_max_life %>
+        max_renewable_life = <%= @kdc_max_renewable_life %>
+        master_key_type = <%= @kdc_master_key_type %>
+        supported_enctypes = <%= @kdc_supported_enctypes.join(" ") %>
         default_principal_flags = +preauth
+<% if @kdc_pkinit_identity -%>
+        pkinit_identity = <%= @kdc_pkinit_identity %>
+<% end -%>
+<% if @pkinit_anchors -%>
+        pkinit_anchors = <%= @pkinit_anchors %>
+<% end -%>
+<% if @kdc_iprop_port -%>
+        iprop_port = <%= @kdc_iprop_port %>
+<% end -%>
+<% if @kdc_iprop_logfile -%>
+        iprop_logfile = <%= @kdc_iprop_logfile %>
+<% end -%>
+<% if @kdc_iprop_resync_timeout -%>
+        iprop_resync_timeout = <%= @kdc_iprop_resync_timeout %>
+<% end -%>
     }
+
+[logging]
+<% if @kdc_logfile -%>
+        kdc = <%= @kdc_logfile %>
+<% end -%>
+<% if @kadmind_logfile -%>
+        admin_server = <%= @kadmind_logfile %>
+<% end -%>

--- a/templates/kprop.cron.erb
+++ b/templates/kprop.cron.erb
@@ -1,0 +1,14 @@
+#!/bin/sh
+RC=0
+DUMP="<%= @kdc_database_dir %>/kdb_dump"
+<%= @kdb5_util_path %> dump "$DUMP"
+<% @kdc_slaves.each do |slave| -%>
+
+<%= @kprop_path %> -f "$DUMP" <%= slave %>
+if [ $? != 0 ]; then
+  /usr/bin/logger "`basename $0`: failed to replicate krb5 database to <%= slave %>"
+  RC=1
+fi
+<% end -%>
+
+exit $RC

--- a/templates/kpropd.acl.erb
+++ b/templates/kpropd.acl.erb
@@ -1,0 +1,1 @@
+<%= @kpropd_master_principal %>

--- a/templates/krb5.conf.erb
+++ b/templates/krb5.conf.erb
@@ -6,58 +6,32 @@
 	krb4_realms = /etc/krb.realms
 	kdc_timesync = 1
 	ccache_type = 4
-	forwardable = true
-	proxiable = true
+	forwardable =  <%= @forwardable %>
+	proxiable = <%= @proxiable %>
+<% if @pkinit_anchors -%>
+	pkinit_anchors = <%= @pkinit_anchors %>
+<% end -%>
 
         # set to true for OpenAFS to work
         allow_weak_crypto = <%= @allow_weak_crypto %>
 
-# The following encryption type specification will be used by MIT Kerberos
-# if uncommented.  In general, the defaults in the MIT Kerberos code are
-# correct and overriding these specifications only serves to disable new
-# encryption types as they are added, creating interoperability problems.
-#
-# Thie only time when you might need to uncomment these lines and change
-# the enctypes is if you have local software that will break on ticket
-# caches containing ticket encryption types it doesn't know about (such as
-# old versions of Sun Java).
-
-#	default_tgs_enctypes = des3-hmac-sha1
-#	default_tkt_enctypes = des3-hmac-sha1
-#	permitted_enctypes = des3-hmac-sha1
-
 # The following libdefaults parameters are only for Heimdal Kerberos.
-	v4_instance_resolve = false
-	v4_name_convert = {
-		host = {
-			rcmd = host
-			ftp = ftp
-		}
-		plain = {
-			something = something-else
-		}
-	}
 	fcc-mit-ticketflags = true
 
 [realms]
         <%= @realm %> = {
-             <% kdc.each do |val| -%>
-             kdc = <%= val %>
-             <% end -%>
-             admin_server = <%= @admin_server %>
+<% @kdcs.each do |val| -%>
+                kdc = <%= val %>
+<% end -%>
+<% if @master_kdc -%>
+                master_kdc = <%= @master_kdc %>
+<% end -%>
+<% if @admin_server -%>
+                admin_server = <%= @admin_server %>
+<% end -%>
         }
 
 [domain_realm]
-  <% domain_realm_list.each_pair do |key, val| -%>
+<% domain_realm_list.each_pair do |key, val| -%>
         <%= key %> = <%= val %>
-  <% end -%>
-
-[login]
-	krb4_convert = true
-	krb4_get_tickets = false
-
-<% if @kdc_logfile or @admin_logfile -%>
-[logging]
-        kdc = <%= @kdc_logfile %>
-        admin_server = <%= @admin_logfile %>
 <% end -%>


### PR DESCRIPTION
Hi Jason,

I did some enhancements to your module which turned out to be a bit of a rewrite unfortunately. On the up-side the list of new features turned out rather long as well. Would you be interested in merging back those changes? If so, how would you like to go about it rather than just dumping this huge merge onto it. ;)

Thanks,
Michael

Separate server classes out into server components living in namespace
kerberos::server and server roles living in namespace kerberos::kdc. Add
slave role with replication using kprop/kpropd. Support bootstrapping
master/slave constructions including forcing a kprop push as well as
waiting for the database to appear before starting the KDC on the slave.

Remove long-dead configuration options and provide reasonable parameter
defaults for current installations.

Allow for local and remote usage of kadmin for adding principals. Remote
usage can use keytab or credential cache.

Add types for creating keytab files and exporting keys into them.

Add type for obtaining tickets and storing them in ticket caches using a
keytab file or PKINIT. Add a class for creating a "host" ticket cache
meant for use by puppet for e.g. kadmin.

Add host_keytab type for drop-in compatibility with Bigtop Hadoop
framwork puppet classes.

Uh, forgot in the commit message:
- support trocla for generating passwords
- automatically create principals and keytabs necessary for replication (if PKINIT is available)