### PR TITLE
Support Debian with Puppet 3

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,7 +9,7 @@
 class kerberos::params {
 
   case $::operatingsystem {
-    Ubuntu: {
+    Ubuntu, Debian: {
       $client_packages    = [ 'krb5-user' ]
       $kdc_server_packages    = [ 'krb5-kdc' ]
       $kadmin_server_packages = [ 'krb5-admin-server' ]


### PR DESCRIPTION
Add Debian to params defaults clause. Remove dependency on
Exec["initialize_dev_random"] that's nowhere to be found. Change default
for hiera lookups to empty hash because that's what create_resources
expects.

Only try to delete from realms hash if that key exists in the trusted
hash. Weird error 'Could not intern from data: Could not find
relationship target "Kerberos::Trust[]"' ensues otherwise.

Enhancement: Make hiera lookups hash merges to take advantage of hiera
lookup hierarchy flexibility. Could just be class parameters otherwise.

Cleanup: Move hiera keys into kerberos:: namespace to avoid
conflicts/namespace pollution.