### PR TITLE
Fix and enhance addprinc type

### DIFF
--- a/manifests/addprinc.pp
+++ b/manifests/addprinc.pp
@@ -1,14 +1,57 @@
+# === Type: kerberos::addprinc
+#
+# Adds a kerberos principal to the KDC database. Supports use of kadmin.local
+# or kadmin. The latter supports use of a ticket cache or a keytab file.
+#
 # === Authors
 #
 # Author Name <greg.1.anderson@greenknowe.org>
+# Additions by Michael Weiser <michael.weiser@gmx.de>
 #
 # === Copyright
 #
 # Copyright 2014 Jason Edgecombe (Copyright assigned by original author)
 #
-define kerberos::addprinc($principal_name = $title, $password = 'password', $flags = '') {
+define kerberos::addprinc($principal_name = $title, $password = undef, $flags = '',
+  $local = true, $kadmin_ccache = undef, $keytab = undef,
+  $tries = undef, $try_sleep = undef,
+) {
+  if $local {
+    # if we're gonna run kadmin.local we better make sure it's
+    # installed
+    include kerberos::server::kadmind
+    $kadmin = "kadmin.local"
+  } else {
+    # if we're gonna run kadmin we better make sure it's installed
+    # and configured
+    include kerberos::client
+    $kadmin = "kadmin"
+
+    $ccache_par = $kadmin_ccache ? {
+      undef => "",
+      default => "-c '$kadmin_ccache'"
+    }
+
+    $keytab_par = $keytab ? {
+      undef => "",
+      default => "-k -t '$keytab'"
+    }
+  }
+
+  $password_par = $password ? {
+    undef => "-nokey",
+    default => "-pw $password"
+  }
+
   exec { "add_principal_$principal_name":
-    command => "kadmin.local -q 'addprinc $flags -pw $password $principal_name'",
-    require => [ Package['krb5-kadmind-server-packages'], Service['krb5-kdc'], ],
+    command => "$kadmin $ccache_par $keytab_par -q 'addprinc $flags $password_par $principal_name'",
+    path => [ "/usr/sbin", "/usr/bin" ],
+    require => $local ? {
+      true => [ Package['krb5-kadmind-server-packages'],
+        Exec['create_krb5kdc_principal'], ],
+      default => [ Package['krb5-client-packages'], File['krb5.conf'] ],
+    },
+    tries => $kadmin_tries,
+    try_sleep => $kadmin_try_sleep,
   }
 }


### PR DESCRIPTION
Add path so that puppet does not complain: "... is not qualified and no
path was specified."

Support use of kadmin as well as kadmin.local distinguished by the local
property. Support use of ticket cache as well as keytab for kadmin.
Support retry in case kadmind is restarting or similar.

Do not create principals with insecure default password. Instead use
-nokey to create them without a key.

Do not require the KDC to be running but the database to be created for
kadmin.local. Do include the kadmind class to make sure the package
containing kadmin.local is getting installed.