### PR TITLE
Add types for keytabs and ticket caches

### DIFF
--- a/manifests/keytab.pp
+++ b/manifests/keytab.pp
@@ -1,0 +1,26 @@
+# === Type: kerberos::keytab
+#
+# Creates an empty (!) keytab for later addition of keys using kerberos::ktadd.
+# Can force specific owner, group and mode on the file.
+#
+# === Authors
+#
+# Michael Weiser <michael.weiser@gmx.de>
+#
+
+define kerberos::keytab($keytab = $title,
+  $mode = "0400", $owner = 0, $group = 0,
+  $replace = false,
+) {
+  # TODO: Avoid recreation if already existing but do update if keys get to
+  # old...
+  file { $keytab:
+    ensure => file,
+    replace => $replace,
+    backup => false,
+    content => inline_template('<%= "\x05\x02" %>'),
+    owner => $owner,
+    group => $group,
+    mode => $mode,
+  }
+}

--- a/manifests/ktadd.pp
+++ b/manifests/ktadd.pp
@@ -1,0 +1,55 @@
+# === Type: kerberos::ktadd
+#
+# Adds a kerberos key to a keytab. Supports use of kadmin.local or kadmin. The
+# latter supports use of a ticket cache or a keytab file.
+#
+# === Authors
+#
+# Michael Weiser <michael.weiser@gmx.de>
+#
+
+# infer principal and keytab file names from title if not given explicitly,
+# syntax: <keytab>@<principal_possibly_containing_more_@s>
+define kerberos::ktadd(
+  $keytab = regsubst($title, "@.*$", ""),
+  $principal = regsubst($title, "^[^@]*@", ""),
+  $local = true, $reexport = false,
+  $kadmin_ccache = undef, $kadmin_keytab = undef,
+  $kadmin_tries = undef, $kadmin_try_sleep = undef,
+) {
+  if $local {
+    $kadmin = "kadmin.local"
+    Package['krb5-kadmind-server-packages'] -> Exec["ktadd_${keytab}_${principal}"]
+    Exec['create_krb5kdc_principal'] -> Exec["ktadd_${keytab}_${principal}"]
+  } else {
+    $kadmin = "kadmin"
+
+    $ccache_par = $kadmin_ccache ? {
+      undef   => "",
+      default => "-c '$kadmin_ccache'"
+    }
+
+    $keytab_par = $kadmin_keytab ? {
+      undef   => "",
+      default => "-k '$kadmin_keytab'"
+    }
+
+    Package['krb5-client-packages'] -> Exec["ktadd_${keytab}_${principal}"]
+    File['krb5.conf'] -> Exec["ktadd_${keytab}_${principal}"]
+  }
+
+  if $reexport {
+    $unless = undef
+  } else {
+    $unless = "klist -k '${keytab}' | grep ' ${principal}@'"
+  }
+
+  exec { "ktadd_${keytab}_${principal}":
+    command => "$kadmin $ccache_par $keytab_par -q 'ktadd -k $keytab $principal'",
+    unless  => $unless,
+    path    => [ "/bin", "/usr/bin", "/usr/bin", "/usr/sbin" ],
+    require => File[$keytab],
+    tries => $kadmin_tries,
+    try_sleep => $kadmin_try_sleep,
+  }
+}

--- a/manifests/ticket_cache.pp
+++ b/manifests/ticket_cache.pp
@@ -1,0 +1,43 @@
+# === Type: kerberos::ticket_cache
+#
+# Requests a TGT and puts it in a ticket cache. Supports use of a keytab file
+# or PKINIT.
+#
+# === Authors
+#
+# Michael Weiser <michael.weiser@gmx.de>
+#
+define kerberos::ticket_cache ($ccname = $title,
+    $principal = "",
+    $keytab = undef,
+    $service = undef,
+    $pkinit = false,
+    $pkinit_cert = "/var/lib/puppet/ssl/certs/${fqdn}.pem",
+    $pkinit_key = "/var/lib/puppet/ssl/private_keys/${fqdn}.pem") {
+  # this needs to be a client in order to run kinit and kadmin
+  include kerberos::client
+
+  $kinit = "kinit"
+  $keytab_par = $keytab ? {
+    undef   => "",
+    default => " -k -t '$keytab'"
+  }
+
+  $pkinit_par = $pkinit ? {
+    undef   => "",
+    default => " -X 'X509_user_identity=FILE:${pkinit_cert},${pkinit_key}'"
+  }
+
+  $service_par = $service ? {
+    undef   => "",
+    default => "-S '$service'"
+  }
+
+  exec { "ticket_cache_$title":
+    command => "kinit -c '$ccname' $keytab_par $pkinit_par $service_par $principal",
+    path    => "/usr/bin",
+    require => [ Package['krb5-client-packages'], File['krb5.conf'] ],
+    # always recreate (for now) to avoid expired tickets
+    # creates => $ccname
+  }
+}


### PR DESCRIPTION
Add types that support the creation of keytabs, adding keys to them
using ktadd and acquiring tickets and putting them in tickets caches.
Keys can be exported using either kadmin.local or kadmin. A large number
of properties can be specified as to who the files should belong to and
whether they should be recreated each run or left alone once created.