### PR TITLE
Change parameter passing and defaulting logic

### DIFF
--- a/README
+++ b/README
@@ -22,23 +22,37 @@ Example Use
 -----------
 
     # Kerberos server (kdc and kadmin)
-    include kerberos::server::kadmind
-
-    class {'kerberos::server::kdc':
+    class {'kerberos':
+      master => true,
       realm => 'EXAMPLE.ORG',
+      kdc_database_password => 'secret',
     }
 
     # kerberos client
-    class {'kerberos::client':
+    class {'kerberos':
+      client            => true,
       realm             => 'EXAMPLE.ORG',
       domain_realm      => { '.example.org' => 'EXAMPLE.ORG', },
-      kdc               => ['cellserver.example.org'],
+      kdcs              => ['cellserver.example.org'],
       admin_server      => 'cellserver.example.org',
       allow_weak_crypto => true,
     }
 
 Hiera Usage
 -----------
+
+Define all the main class parameters you'd like to change like this:
+
+kerberos::realm: 'EXAMPLE.ORG'
+kerberos::kdcs:
+  - 'cellserver.example.org'
+
+Forget about client => true. Just include or hiera_include() any of the
+following classes:
+
+kerberos::client
+kerberos::server::kdc
+kerberos::server::kadmind
 
 It is best to store passwords in Hiera; that way, you can have a set of test
 credentials, and a different set of credentials for production servers.  For
@@ -65,7 +79,7 @@ in a more secure location.
 
   production.yaml:
   ---
-  kerberos::server::kdc::master_password: verylongsecurerandomlyproducedpassword
+  kerberos::kdc_database_password: verylongsecurerandomlyproducedpassword
 
   trusted_realms:
     realms:

--- a/manifests/base.pp
+++ b/manifests/base.pp
@@ -1,12 +1,15 @@
+# == Class: kerberos::base
+#
 # === Authors
 #
 # Author Name <jason@rampaginggeek.com>
+# Additions by Michael Weiser <michael.weiser@gmx.de>
 #
 # === Copyright
 #
 # Copyright 2013 Jason Edgecombe, unless otherwise noted.
 #
-class kerberos::base {
-  include kerberos::params
-
+class kerberos::base inherits kerberos {
+  # very common base logic will go here, like installing pkinit packages on
+  # client and server
 }

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -1,20 +1,29 @@
-# Valid values for $kdc_logfile and $admin_logfile include:
-#   FILE:/var/log/kdc.log
-#   CONSOLE
-#   SYSLOG:INFO:DAEMON
-#   DEVICE=/dev/tty04
+# == Class: kerberos::client
+#
+# Install and configure the client, mostly krb5.conf.
 #
 # === Authors
 #
 # Author Name <jason@rampaginggeek.com>
+# Additions by Michael Weiser <michael.weiser@gmx.de>
 #
 # === Copyright
 #
 # Copyright 2013 Jason Edgecombe, unless otherwise noted.
 #
-class kerberos::client($realm = 'EXAMPLE.COM', $domain_realm = {}, $kdc = [], $admin_server = [],
-  $allow_weak_crypto = false, $kdc_logfile = 'FILE:/var/log/kdc.log', $admin_logfile = 'FILE:/var/log/kerberos_admin_server.log') inherits kerberos::base {
+class kerberos::client (
+  $krb5_conf_path = $kerberos::krb5_conf_path,
+  $realm = $kerberos::realm,
+  $domain_realm = $kerberos::domain_realm,
+  $kdcs = $kerberos::kdcs,
+  $master_kdc = $kerberos::master_kdc,
+  $admin_server = $kerberos::admin_server,
+  $allow_weak_crypto = $kerberos::allow_weak_crypto,
+  $forwardable = $kerberos::forwardable,
+  $proxiable = $kerberos::proxiable,
 
+  $client_packages = $kerberos::client_packages,
+) inherits kerberos {
   include kerberos::base
 
   # Provide default content for domain_realm if the user did not
@@ -30,13 +39,13 @@ class kerberos::client($realm = 'EXAMPLE.COM', $domain_realm = {}, $kdc = [], $a
 
   package { 'krb5-client-packages' :
     ensure => present,
-    name   => $kerberos::params::client_packages,
+    name   => $client_packages,
     before => File['krb5.conf'],
   }
 
   file { 'krb5.conf':
     ensure  => file,
-    path    => $kerberos::params::krb5_conf_path,
+    path    => $krb5_conf_path,
     content => template('kerberos/krb5.conf.erb'),
     mode    => '0644',
     owner   => 0,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,41 +1,171 @@
 # == Class: kerberos
 #
-# Full description of class kerberos here.
+# Base class for the module. Provides parameter defaulting from
+# kerberos::params with override via hiera lookups.
 #
 # === Parameters
 #
-# Document parameters here.
+# Paths:
 #
-# [*sample_parameter*]
-#   Explanation of what this parameter affects and what it defaults to.
-#   e.g. "Specify one or more upstream ntp servers as an array."
+# $krb5_conf_path:
+#   Path to the client configuration file.
 #
-# === Variables
+# $kdc_conf_path = $kerberos::params::kdc_conf_path,
+#   Path to the main KDC configuration file.
 #
-# Here you should define a list of variables that this module would require.
+# $kadm5_acl_path = $kerberos::params::kadm5_acl_path,
+#   Path to the admin service ACL file.
 #
-# [*sample_variable*]
-#   Explanation of how this variable affects the funtion of this class and if it
-#   has a default. e.g. "The parameter enc_ntp_servers must be set by the
-#   External Node Classifier as a comma separated list of hostnames." (Note,
-#   global variables should not be used in preference to class parameters  as of
-#   Puppet 2.6.)
+# $kdb5_util_path = $kerberos::params::kdb5_util_path,
+#   Path of kdb5_util used for creating databases.
 #
-# === Examples
+# Settings in files:
 #
-#  class { kerberos:
-#    servers => [ 'pool.ntp.org', 'ntp.local.company.com' ]
-#  }
+# krb5.conf
+# $realm:
+#   The Kerberos realm (e.g. 'EXAMPLE.COM')
 #
+# $domain_realm
+#   Hash of domain to realm mappings.
+#
+# $kdcs
+#   Array of KDCs to configure.
+#
+# $master_kdc
+#   The master KDC to configure (used for password changes).
+#
+# $admin_server
+#   The admin service to use.
+#
+# $allow_weak_crypto
+#   Re-enable Single-DES.
+#
+# $forwardable
+#   Request forwardable tickets by default.
+#
+# $proxiable
+#   Request proxiable tickets by default.
+#
+# kdc.conf
+# $kdc_ports
+#   Ports to have the KDC listen on.
+#
+# $kdc_database_path
+#   Path to the principal database.
+#
+# $kdc_stash_path
+#   Path to key stash.
+#
+# $kdc_max_life
+#   Maximum ticket lifetime allowed by the KDC.
+#
+# $kdc_max_renewable_life
+#   Maximum renewable lifetime allowed by the KDC.
+#
+# $kdc_master_key_type
+#   The key type to use to encrypt the principal database.
+#
+# $kdc_supported_enctypes
+#   List of encryption types supported by the KDC.
+#
+# $kdc_logfile
+# no kadm5.conf, so it's in kdc.conf
+# $kadmind_logfile
+#   Valid values for $kdc_logfile and $kadmind_logfile include:
+#   FILE:/var/log/kdc.log
+#   CONSOLE
+#   SYSLOG:INFO:DAEMON
+#   DEVICE=/dev/tty04
+#
+# $kdc_principals
+# $kdc_trusted_realms
+#   Principals and realm trusts to be created on the master.
+#
+# $kadmind_acls
+#   ACLs for for the admin service.
+#
+# $client_packages
+# $kdc_server_packages
+# $kadmin_server_packages
+#   Package names.
+#
+# === References
+#
+# [1] http://web.mit.edu/kerberos/krb5-1.6/krb5-1.6.3/doc/krb5-install.html#Create-the-Database
+#
+# [2] http://web.mit.edu/kerberos/krb5-1.6/krb5-1.6.3/doc/krb5-install.html#Add-Administrators-to-the-Acl-File
+#
+# [3] http://web.mit.edu/kerberos/krb5-1.6/krb5-1.6.3/doc/krb5-install.html#Create-a-kadmind-Keytab-_0028optional_0029
 # === Authors
 #
 # Author Name <jason@rampaginggeek.com>
+# Additions by Michael Weiser <michael.weiser@gmx.de>
 #
 # === Copyright
 #
 # Copyright 2013 Jason Edgecombe, unless otherwise noted.
 #
-class kerberos {
+class kerberos(
+  # roles
+  $client = false,
+  $master = false,
 
+  # paths to configuration files
+  $krb5_conf_path = $kerberos::params::krb5_conf_path,
+  $kdc_conf_path = $kerberos::params::kdc_conf_path,
+  $kadm5_acl_path = $kerberos::params::kadm5_acl_path,
+  $kdb5_util_path = $kerberos::params::kdb5_util_path,
 
+  # settings in files
+  $realm = 'EXAMPLE.COM',
+  $domain_realm = {},
+  $kdcs = [],
+  $master_kdc = undef,
+  $admin_server = undef,
+  $allow_weak_crypto = false,
+  $forwardable = true,
+  $proxiable = true,
+
+  $kdc_ports = '88',
+  $kdc_database_path = $kerberos::params::kdc_database_path,
+  $kdc_database_password = undef,
+  $kdc_stash_path = $kerberos::params::kdc_stash_path,
+  $kdc_max_life = '10h 0m 0s',
+  $kdc_max_renewable_life = '7d 0h 0m 0s',
+  $kdc_master_key_type = 'aes256-cts',
+  $kdc_supported_enctypes = ['aes256-cts:normal', 'arcfour-hmac:normal', 'des3-hmac-sha1:normal' ],
+  $kdc_logfile = $kerberos::params::kdc_logfile,
+
+  # no kadm5.conf, so it's in kdc.conf
+  $kadmind_logfile = $kerberos::params::kadmind_logfile,
+
+  # settings to be implemented via logic
+  $kdc_principals = {},
+  $kdc_trusted_realms = {},
+
+  $kadmind_acls = { "*/admin@$realm" => '*' },
+
+  # packages
+  $client_packages = $kerberos::params::client_packages,
+  $kdc_server_packages = $kerberos::params::kdc_server_packages,
+  $kadmin_server_packages = $kerberos::params::kadmin_server_packages,
+) inherits kerberos::params {
+  $kdc_logfile_cfg = $kdc_logfile ? {
+    undef => undef,
+    default => regsubst($kdc_logfile, "^/", "FILE:/")
+  }
+
+  $kadmind_logfile_cfg = $kadmind_logfile ? {
+    undef => undef,
+    default => regsubst($kadmind_logfile, "^/", "FILE:/")
+  }
+
+  if $client {
+    include kerberos::client
+  }
+
+  if $master {
+    include kerberos::server::kdc
+    include kerberos::server::kadmind
+  }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,6 +1,12 @@
+# == Class: kerberos::params
+#
+# Provides platform-dependant default values for certain parameters of the main
+# kerberos class.
+#
 # === Authors
 #
 # Jason Edgecombe <jason@rampaginggeek.com>
+# Additions by Michael Weiser <michael.weiser@gmx.de>
 #
 # === Copyright
 #
@@ -13,12 +19,14 @@ class kerberos::params {
       $client_packages    = [ 'krb5-user' ]
       $kdc_server_packages    = [ 'krb5-kdc' ]
       $kadmin_server_packages = [ 'krb5-admin-server' ]
+
       $krb5_conf_path         = '/etc/krb5.conf'
       $kdc_conf_path          = '/etc/krb5kdc/kdc.conf'
       $kadm5_acl_path         = '/etc/krb5kdc/kadm5.acl'
-      $krb5kdc_database_path  = '/var/lib/krb5kdc/principal'
-      $admin_keytab_path      = '/etc/krb5kdc/kadm5.keytab'
-      $key_stash_path         = '/etc/krb5kdc/stash'
+      $kdc_database_path      = '/var/lib/krb5kdc/principal'
+      $kdc_stash_path         = '/etc/krb5kdc/stash'
+      $kdc_logfile            = '/var/log/kdc.log'
+      $kadmind_logfile        = '/var/log/kerberos_admin_server.log'
     }
     default: {
       fail("The ${module_name} module is not supported on ${::osfamily} based systems")

--- a/manifests/server/kadmind.pp
+++ b/manifests/server/kadmind.pp
@@ -1,17 +1,18 @@
 # === Authors
 #
 # Author Name <jason@rampaginggeek.com>
+# Additions by Michael Weiser <michael.weiser@gmx.de>
 #
 # === Copyright
 #
 # Copyright 2013 Jason Edgecombe, unless otherwise noted.
 #
-class kerberos::server::kadmind {
-  include kerberos::base
-
+class kerberos::server::kadmind (
+  $kadmin_server_packages = $kerberos::kadmin_server_packages,
+) inherits kerberos {
   package { 'krb5-kadmind-server-packages' :
     ensure => present,
-    name   => $kerberos::params::kadmin_server_packages,
+    name   => $kadmin_server_packages,
   }
 
   service { 'krb5-admin-server':

--- a/templates/kadm5.acl.erb
+++ b/templates/kadm5.acl.erb
@@ -1,3 +1,3 @@
-<% acl.each_pair do |principal, val| -%>
+<% @kadmind_acls.each_pair do |principal, val| -%>
 <%= principal %> <%= val %>
 <% end -%>

--- a/templates/kdc.conf.erb
+++ b/templates/kdc.conf.erb
@@ -1,16 +1,22 @@
 [kdcdefaults]
-    kdc_ports = 750,88
+    kdc_ports = <%= @kdc_ports %>
 
 [realms]
     <%= @realm %> = {
-        database_name = <%= @krb5kdc_database_path %>
-        admin_keytab = FILE:<%= @admin_keytab_path %>
+        database_name = <%= @kdc_database_path %>
         acl_file = <%= @kadm5_acl_path %>
-        key_stash_file = <%= @key_stash_path %>
-        kdc_ports = 750,88
-        max_life = 10h 0m 0s
-        max_renewable_life = 7d 0h 0m 0s
-        master_key_type = des3-hmac-sha1
-        supported_enctypes = aes256-cts:normal arcfour-hmac:normal des3-hmac-sha1:normal des-cbc-crc:normal des:normal des:v4 des:norealm des:onlyrealm des:afs3
+        key_stash_file = <%= @kdc_stash_path %>
+        max_life = <%= @kdc_max_life %>
+        max_renewable_life = <%= @kdc_max_renewable_life %>
+        master_key_type = <%= @kdc_master_key_type %>
+        supported_enctypes = <%= @kdc_supported_enctypes.join(" ") %>
         default_principal_flags = +preauth
     }
+
+[logging]
+<% if @kdc_logfile -%>
+        kdc = <%= @kdc_logfile %>
+<% end -%>
+<% if @kadmind_logfile -%>
+        admin_server = <%= @kadmind_logfile %>
+<% end -%>

--- a/templates/krb5.conf.erb
+++ b/templates/krb5.conf.erb
@@ -6,58 +6,29 @@
 	krb4_realms = /etc/krb.realms
 	kdc_timesync = 1
 	ccache_type = 4
-	forwardable = true
-	proxiable = true
+	forwardable = <%= @forwardable %>
+	proxiable = <%= @proxiable %>
 
         # set to true for OpenAFS to work
         allow_weak_crypto = <%= @allow_weak_crypto %>
 
-# The following encryption type specification will be used by MIT Kerberos
-# if uncommented.  In general, the defaults in the MIT Kerberos code are
-# correct and overriding these specifications only serves to disable new
-# encryption types as they are added, creating interoperability problems.
-#
-# Thie only time when you might need to uncomment these lines and change
-# the enctypes is if you have local software that will break on ticket
-# caches containing ticket encryption types it doesn't know about (such as
-# old versions of Sun Java).
-
-#	default_tgs_enctypes = des3-hmac-sha1
-#	default_tkt_enctypes = des3-hmac-sha1
-#	permitted_enctypes = des3-hmac-sha1
-
 # The following libdefaults parameters are only for Heimdal Kerberos.
-	v4_instance_resolve = false
-	v4_name_convert = {
-		host = {
-			rcmd = host
-			ftp = ftp
-		}
-		plain = {
-			something = something-else
-		}
-	}
 	fcc-mit-ticketflags = true
 
 [realms]
         <%= @realm %> = {
-             <% kdc.each do |val| -%>
-             kdc = <%= val %>
-             <% end -%>
-             admin_server = <%= @admin_server %>
+<% @kdcs.each do |val| -%>
+                kdc = <%= val %>
+<% end -%>
+<% if @master_kdc -%>
+                master_kdc = <%= @master_kdc %>
+<% end -%>
+<% if @admin_server -%>
+                admin_server = <%= @admin_server %>
+<% end -%>
         }
 
 [domain_realm]
-  <% domain_realm_list.each_pair do |key, val| -%>
+<% domain_realm_list.each_pair do |key, val| -%>
         <%= key %> = <%= val %>
-  <% end -%>
-
-[login]
-	krb4_convert = true
-	krb4_get_tickets = false
-
-<% if @kdc_logfile or @admin_logfile -%>
-[logging]
-        kdc = <%= @kdc_logfile %>
-        admin_server = <%= @admin_logfile %>
 <% end -%>


### PR DESCRIPTION
Have class kerberos pull platform depdendant parameters out of class
params. Define all module parameters at class kerberos for easy passing
by user and single-namespace lookups into hiera (all in kerberos::).

Make all other classes inherit from class kerberos so those values are
known. Declare all used variables as parameters although they'd be known
through scoping anyway for housekeeping to know what's used where.

User-visibile changes: For hiera use the namespace in datasources
changes to kerberos:: consistently. Apart from that classes are just
included as before.

For direct resource-like use the classes can also be used as before. But
with further refactoring parameters will move away from them into other
classes removing the means to specify parameters such as realm at the
kdc class. In anticipation of this provide a simple role selection at
the kerberos class using booleans "client" and "master" ("slave" is to
follow) which includes the correct classes from there.

Make more parameters adjustable in krb5.conf and kdc.conf. Move log
file paths from krb5.conf to kdc.conf, nicely removing interdependance
between client and server roles. Provide real-world up-to-date defaults.
Remove Kerberos 4 cruft (like listening to port 750). Remove
kadmin.keytab which kadmind doesn't need any more.