### PR TITLE
Add support for using PKINIT

### DIFF
--- a/manifests/base.pp
+++ b/manifests/base.pp
@@ -9,7 +9,14 @@
 #
 # Copyright 2013 Jason Edgecombe, unless otherwise noted.
 #
-class kerberos::base inherits kerberos {
-  # very common base logic will go here, like installing pkinit packages on
-  # client and server
+class kerberos::base (
+  $pkinit_anchors = $kerberos::pkinit_anchors,
+  $pkinit_packages = $kerberos::pkinit_packages,
+) inherits kerberos {
+  if $pkinit_anchors {
+    package { 'krb5-pkinit-packages':
+      ensure => present,
+      name   => $pkinit_packages,
+    }
+  }
 }

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -21,6 +21,7 @@ class kerberos::client (
   $allow_weak_crypto = $kerberos::allow_weak_crypto,
   $forwardable = $kerberos::forwardable,
   $proxiable = $kerberos::proxiable,
+  $pkinit_anchors = $kerberos::pkinit_anchors_cfg,
 
   $client_packages = $kerberos::client_packages,
 ) inherits kerberos {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -46,6 +46,9 @@
 # $proxiable
 #   Request proxiable tickets by default.
 #
+# $pkinit_anchors
+#   Path to CA certificate to use for PKINIT.
+#
 # kdc.conf
 # $kdc_ports
 #   Ports to have the KDC listen on.
@@ -68,6 +71,11 @@
 # $kdc_supported_enctypes
 #   List of encryption types supported by the KDC.
 #
+# $kdc_pkinit_identity
+#   Certificate and private key to use for PKINIT at the KDC. Format: <path to
+#   cert>,<path to key>. FILE: is prepended automatically if beginning with a
+#   slash.
+#
 # $kdc_logfile
 # no kadm5.conf, so it's in kdc.conf
 # $kadmind_logfile
@@ -84,6 +92,7 @@
 # $kadmind_acls
 #   ACLs for for the admin service.
 #
+# $pkinit_packages
 # $client_packages
 # $kdc_server_packages
 # $kadmin_server_packages
@@ -96,6 +105,7 @@
 # [2] http://web.mit.edu/kerberos/krb5-1.6/krb5-1.6.3/doc/krb5-install.html#Add-Administrators-to-the-Acl-File
 #
 # [3] http://web.mit.edu/kerberos/krb5-1.6/krb5-1.6.3/doc/krb5-install.html#Create-a-kadmind-Keytab-_0028optional_0029
+#
 # === Authors
 #
 # Author Name <jason@rampaginggeek.com>
@@ -125,6 +135,7 @@ class kerberos(
   $allow_weak_crypto = false,
   $forwardable = true,
   $proxiable = true,
+  $pkinit_anchors = undef,
 
   $kdc_ports = '88',
   $kdc_database_path = $kerberos::params::kdc_database_path,
@@ -134,6 +145,7 @@ class kerberos(
   $kdc_max_renewable_life = '7d 0h 0m 0s',
   $kdc_master_key_type = 'aes256-cts',
   $kdc_supported_enctypes = ['aes256-cts:normal', 'arcfour-hmac:normal', 'des3-hmac-sha1:normal' ],
+  $kdc_pkinit_identity = undef,
   $kdc_logfile = $kerberos::params::kdc_logfile,
 
   # no kadm5.conf, so it's in kdc.conf
@@ -146,6 +158,7 @@ class kerberos(
   $kadmind_acls = { "*/admin@$realm" => '*' },
 
   # packages
+  $pkinit_packages = $kerberos::params::pkinit_packages,
   $client_packages = $kerberos::params::client_packages,
   $kdc_server_packages = $kerberos::params::kdc_server_packages,
   $kadmin_server_packages = $kerberos::params::kadmin_server_packages,
@@ -158,6 +171,16 @@ class kerberos(
   $kadmind_logfile_cfg = $kadmind_logfile ? {
     undef => undef,
     default => regsubst($kadmind_logfile, "^/", "FILE:/")
+  }
+
+  $pkinit_anchors_cfg = $pkinit_anchors ? {
+    undef => undef,
+    default => regsubst($pkinit_anchors, "^/", "FILE:/")
+  }
+
+  $kdc_pkinit_identity_cfg = $kdc_pkinit_identity ? {
+    undef => undef,
+    default => regsubst($kdc_pkinit_identity, "^/", "FILE:/")
   }
 
   if $client {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -19,6 +19,7 @@ class kerberos::params {
       $client_packages    = [ 'krb5-user' ]
       $kdc_server_packages    = [ 'krb5-kdc' ]
       $kadmin_server_packages = [ 'krb5-admin-server' ]
+      $pkinit_packages        = [ 'krb5-pkinit' ]
 
       $krb5_conf_path         = '/etc/krb5.conf'
       $kdc_conf_path          = '/etc/krb5kdc/kdc.conf'

--- a/manifests/server/kdc.pp
+++ b/manifests/server/kdc.pp
@@ -35,6 +35,7 @@ class kerberos::server::kdc(
   $kadmind_logfile = $kerberos::kadmind_logfile_cfg,
   $kdc_server_packages = $kerberos::kdc_server_packages,
 ) inherits kerberos {
+  # pkinit packages
   include kerberos::base
 
   package { 'krb5-kdc-server-packages' :
@@ -102,4 +103,7 @@ class kerberos::server::kdc(
     subscribe  => File['kdc.conf'],
     require => Exec["create_krb5kdc_principal"],
   }
+
+  # installed in kerberos::base if enabled
+  Package<| title == 'krb5-pkinit-packages' |> -> Service['krb5kdc']
 }

--- a/templates/kdc.conf.erb
+++ b/templates/kdc.conf.erb
@@ -11,6 +11,12 @@
         master_key_type = <%= @kdc_master_key_type %>
         supported_enctypes = <%= @kdc_supported_enctypes.join(" ") %>
         default_principal_flags = +preauth
+<% if @kdc_pkinit_identity -%>
+        pkinit_identity = <%= @kdc_pkinit_identity %>
+<% end -%>
+<% if @pkinit_anchors -%>
+        pkinit_anchors = <%= @pkinit_anchors %>
+<% end -%>
     }
 
 [logging]

--- a/templates/krb5.conf.erb
+++ b/templates/krb5.conf.erb
@@ -8,6 +8,9 @@
 	ccache_type = 4
 	forwardable = <%= @forwardable %>
 	proxiable = <%= @proxiable %>
+<% if @pkinit_anchors -%>
+	pkinit_anchors = <%= @pkinit_anchors %>
+<% end -%>
 
         # set to true for OpenAFS to work
         allow_weak_crypto = <%= @allow_weak_crypto %>


### PR DESCRIPTION
Hi Jason,

thanks for merging the previous batch of changes! Are you up for some more?

Thanks,
Michael

Add options to krb5.conf and kdc.conf that enable use of PKINIT. Use
class kerberos::base to install the necessary packages on client and
server.