### PR TITLE
Separate roles from server daemons

### DIFF
--- a/README
+++ b/README
@@ -51,8 +51,7 @@ Forget about client => true. Just include or hiera_include() any of the
 following classes:
 
 kerberos::client
-kerberos::server::kdc
-kerberos::server::kadmind
+kerberos::kdc::master
 
 It is best to store passwords in Hiera; that way, you can have a set of test
 credentials, and a different set of credentials for production servers.  For

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -89,6 +89,9 @@
 # $kdc_trusted_realms
 #   Principals and realm trusts to be created on the master.
 #
+# $kadmind_enable
+#   Whether to actually enable kadmind.
+#
 # $kadmind_acls
 #   ACLs for for the admin service.
 #
@@ -97,6 +100,10 @@
 # $kdc_server_packages
 # $kadmin_server_packages
 #   Package names.
+#
+# $kdc_service_name
+# $kadmin_service_name
+#   Service names.
 #
 # === References
 #
@@ -155,6 +162,7 @@ class kerberos(
   $kdc_principals = {},
   $kdc_trusted_realms = {},
 
+  $kadmind_enable = true,
   $kadmind_acls = { "*/admin@$realm" => '*' },
 
   # packages
@@ -162,6 +170,10 @@ class kerberos(
   $client_packages = $kerberos::params::client_packages,
   $kdc_server_packages = $kerberos::params::kdc_server_packages,
   $kadmin_server_packages = $kerberos::params::kadmin_server_packages,
+
+  # service names
+  $kdc_service_name = $kerberos::params::kdc_service_name,
+  $kadmin_service_name = $kerberos::params::kadmin_service_name,
 ) inherits kerberos::params {
   $kdc_logfile_cfg = $kdc_logfile ? {
     undef => undef,
@@ -188,7 +200,6 @@ class kerberos(
   }
 
   if $master {
-    include kerberos::server::kdc
-    include kerberos::server::kadmind
+    include kerberos::kdc::master
   }
 }

--- a/manifests/kdc/master.pp
+++ b/manifests/kdc/master.pp
@@ -1,0 +1,75 @@
+# === Class: kerberos::kdc::master
+#
+# Kerberos master kdc: Sets up the server daemons using kerberos::server::kdc
+# and kerberos::server::kadmind classes.
+#
+# === Authors
+#
+# Jason Edgecombe <jason@rampaginggeek.com>
+#
+# Additions by <greg.1.anderson@greeknowe.org>
+# Additions by Michael Weiser <michael.weiser@gmx.de>
+#
+# === Copyright
+#
+# Copyright 2013 Jason Edgecombe, unless otherwise noted.
+#
+class kerberos::kdc::master (
+  $kadmind_enable = $kerberos::kadmind_enable,
+  $kdc_database_password = $kerberos::kdc_database_password,
+  $kdc_principals = $kerberos::kdc_principals,
+  $kdc_trusted_realms = $kerberos::kdc_trusted_realms,
+
+  $kdb5_util_path = $kerberos::kdb5_util_path,
+) inherits kerberos {
+  # at a minimum a master has a krb5kdc server
+  include kerberos::server::kdc
+
+  # convenience setting for enabling and disabling kadmind
+  if $kadmind_enable {
+    include kerberos::server::kadmind
+  }
+
+  if $kdc_database_password {
+    $db_password = $kdc_database_password
+  } else {
+    $db_password = trocla("kdc_database_password", "plain")
+  }
+
+  exec { "create_krb5kdc_principal":
+    command => "$kdb5_util_path -r $realm -P \'$db_password\' create -s",
+    creates => "$kdc_database_path",
+    require => [ File['krb5-kdc-database-dir', 'kdc.conf'], ],
+  }
+
+  # Look up our users in hiera. Create a principal for each one listed
+  # for this realm.
+  $kerberos_principals = hiera_hash("kerberos::principals", $kdc_principals)
+  create_resources('kerberos::addprinc', $kerberos_principals)
+
+  # KDC database must be created before we can start the KDC service and it
+  # should be restarted if someone deleted its database from underneath it
+  Exec['create_krb5kdc_principal'] ~> Service['krb5kdc']
+
+  # KDC database must be created before *any* principals can be added - duh
+  Exec['create_krb5kdc_principal'] -> Kerberos::Addprinc<||>
+
+  # all principal-adding using kadmin.local should be done before we
+  # start the KDC
+  Kerberos::Addprinc<| local == true |> -> Service['krb5kdc']
+
+  # Look up our trusted realms from hiera. Create trusted principal pairs
+  # for each trusted realm that is not the realm of the current server.
+  $trusted = hiera_hash('kerberos::trusted_realms', $kdc_trusted_realms)
+  if $trusted {
+    if $trusted['realms'] {
+      $trusted_realms = delete($trusted['realms'], $realm)
+    }
+    if $trusted_realms {
+      kerberos::trust { $trusted_realms:
+        this_realm => $realm,
+        password   => $trusted['password'],
+      }
+    }
+  }
+}

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -21,9 +21,14 @@ class kerberos::params {
       $kadmin_server_packages = [ 'krb5-admin-server' ]
       $pkinit_packages        = [ 'krb5-pkinit' ]
 
+      $kdc_service_name       = 'krb5-kdc'
+      $kadmin_service_name    = 'krb5-admin-server'
+
       $krb5_conf_path         = '/etc/krb5.conf'
       $kdc_conf_path          = '/etc/krb5kdc/kdc.conf'
       $kadm5_acl_path         = '/etc/krb5kdc/kadm5.acl'
+      $kdb5_util_path         = '/usr/sbin/kdb5_util'
+
       $kdc_database_path      = '/var/lib/krb5kdc/principal'
       $kdc_stash_path         = '/etc/krb5kdc/stash'
       $kdc_logfile            = '/var/log/kdc.log'

--- a/manifests/server/base.pp
+++ b/manifests/server/base.pp
@@ -1,0 +1,47 @@
+# === Class: kerberos::server::base
+#
+# Kerberos KDC base elements: Generates kdc.conf needed by kdc and kadmind.
+#
+# === Authors
+#
+# Author Name <jason@rampaginggeek.com>
+#
+# Additions by <greg.1.anderson@greeknowe.org>
+# Additions by Michael Weiser <michael.weiser@gmx.de>
+#
+# === Copyright
+#
+# Copyright 2013 Jason Edgecombe, unless otherwise noted.
+#
+class kerberos::server::base (
+  $kdc_conf_path = $kerberos::kdc_conf_path,
+
+  $realm = $kerberos::realm,
+  $kdc_ports = $kerberos::kdc_ports,
+  $kdc_database_path = $kerberos::kdc_database_path,
+  $kdc_stash_path = $kerberos::kdc_stash_path,
+  $kdc_max_life = $kerberos::kdc_max_life,
+  $kdc_max_renewable_life = $kerberos::kdc_max_renewable_life,
+  $kdc_master_key_type = $kerberos::kdc_master_key_type,
+  $kdc_supported_enctypes = $kerberos::kdc_supported_enctypes,
+  $pkinit_anchors = $kerberos::pkinit_anchors_cfg,
+  $kdc_pkinit_identity = $kerberos::kdc_pkinit_identity_cfg,
+  $kdc_logfile = $kerberos::kdc_logfile_cfg,
+  $kadmind_logfile = $kerberos::kadmind_logfile_cfg,
+) inherits kerberos {
+  require stdlib
+  $kdc_conf_dir = dirname($kdc_conf_path)
+  if !defined(File[$kdc_conf_dir]) {
+    file { $kdc_conf_dir: ensure => "directory" }
+  }
+
+  file { 'kdc.conf':
+    ensure  => file,
+    path    => $kdc_conf_path,
+    content => template('kerberos/kdc.conf.erb'),
+    mode    => '0644',
+    owner   => 0,
+    group   => 0,
+    require => File[$kdc_conf_dir],
+  }
+}

--- a/manifests/server/kadmind.pp
+++ b/manifests/server/kadmind.pp
@@ -1,3 +1,9 @@
+# === Class: kerberos::server::kadmind
+#
+# Kerberos admin service. Installs and starts the kadmin service. Does not
+# create the master KDC database though. Use kerberos::kdc::master to set up
+# functioning KDCs.
+#
 # === Authors
 #
 # Author Name <jason@rampaginggeek.com>
@@ -9,17 +15,44 @@
 #
 class kerberos::server::kadmind (
   $kadmin_server_packages = $kerberos::kadmin_server_packages,
+  $kadm5_acl_path = $kerberos::kadm5_acl_path,
+  $kadmind_acls = $kerberos::kadmind_acls,
+  $kadmin_service_name = $kerberos::kadmin_service_name,
 ) inherits kerberos {
+  include kerberos::server::base
+
   package { 'krb5-kadmind-server-packages' :
     ensure => present,
     name   => $kadmin_server_packages,
   }
 
-  service { 'krb5-admin-server':
+  require stdlib
+  $kadm5_acl_dir = dirname($kadm5_acl_path)
+  if !defined(File[$kadm5_acl_dir]) {
+    file { $kadm5_acl_dir: ensure => "directory" }
+  }
+
+  file { 'kadm5.acl':
+    ensure  => file,
+    path    => $kadm5_acl_path,
+    content => template('kerberos/kadm5.acl.erb'),
+    mode    => '0644',
+    owner   => 0,
+    group   => 0,
+    require => File[$kadm5_acl_dir],
+  }
+
+  service { 'kadmind':
+    name       => $kadmin_service_name,
     ensure     => running,
     enable     => true,
     hasrestart => true,
     hasstatus  => true,
-    subscribe  => File['krb5.conf'],
+    require    => Exec["create_krb5kdc_principal"],
+    subscribe  => [ File['kdc.conf', 'kadm5.acl'], Exec['create_krb5kdc_principal'] ],
   }
+
+  # all adding of principals using kadmin can only be done after kadmind
+  # is started
+  Service['kadmind'] -> Kerberos::Addprinc<| local == false |>
 }


### PR DESCRIPTION
Hi Jason,

here's another one. This should be the last fundamental change in class layout. It mostly moves stuff from server/kdc.pp into server/kadmind.pp, server/base.pp and master/kdc.pp After that it should be plug'n'play for replication and the last misc. bits.

Implement a master KDC role (in anticipation of a slave role to follow).
Move database creation from kerberos::server::kdc to the master. Move creation
of kdc.conf into a kerberos::server::base class that's used by kdc and
kadmind. Move creation of kadm5.acl to kerberos::server::kadmind class.

Introduce trocla to automatically generate database password if not set.

Automatically create directories for configuration and database files.

Introduce class parameters to override service names.