### PR TITLE
Add addprinc/keytab/ktadd sequence and host ticket cache

### DIFF
--- a/manifests/addprinc_keytab_ktadd.pp
+++ b/manifests/addprinc_keytab_ktadd.pp
@@ -1,0 +1,63 @@
+# == Type: kerberos::addprinc_keytab_ktadd
+#
+# Wrapper around addprinc, keytab and ktadd. Uses if defined() to only define
+# resources that aren't defined yet. That way, they can be pre-defined from the
+# outside, forcing e.g. specific permissions.
+#
+# === Authors
+#
+# Michael Weiser <michael.weiser@gmx.de>
+#
+define kerberos::addprinc_keytab_ktadd(
+  $keytab = regsubst($title, "@.*$", ""),
+  $principal = regsubst($title, "^[^@]*@", ""),
+  $local = true, $kadmin_ccache = undef, $kadmin_keytab = undef,
+  $kadmin_tries = undef, $kadmin_try_sleep = undef,
+  # only here for host_keytab - define keytab directly if specific permissions
+  # are desired
+  $keytab_owner = 0, $keytab_group = 0, $keytab_mode = "0400"
+) {
+  if $local == false {
+    include kerberos::host_ticket_cache
+    Kerberos::Ticket_cache["krb5-cache-puppet"] ->
+      Kerberos::Addprinc[$principal]
+  }
+
+  # this is why we can only do one principal at a time - if we ever find a way
+  # to check for multiple resources being defined already, we can enhance this
+  # functions to do multiple principals per keytab in one go.
+  if !defined(Kerberos::Addprinc[$principal]) {
+    kerberos::addprinc { $principal:
+      local => $local,
+      kadmin_ccache => $kadmin_ccache,
+      keytab => $kadmin_keytab,
+      tries => $kadmin_tries,
+      try_sleep => $kadmin_try_sleep,
+    }
+  }
+
+  if !defined(Kerberos::Keytab[$keytab]) {
+    kerberos::keytab { $keytab:
+      owner => $keytab_owner,
+      group => $keytab_group,
+      mode => $keytab_mode,
+    }
+  }
+
+  $ktadd = "$keytab@$principal"
+  if !defined(Kerberos::Ktadd[$ktadd]) {
+    kerberos::ktadd { "$ktadd":
+      keytab => $keytab,
+      principal => $principal,
+      local => $local,
+      kadmin_ccache => $kadmin_ccache,
+      kadmin_keytab => $kadmin_keytab,
+      kadmin_tries => $kadmin_tries,
+      kadmin_try_sleep => $kadmin_try_sleep,
+    }
+  }
+
+  Kerberos::Addprinc[$principal] ->
+    Kerberos::Keytab[$keytab] ->
+    Kerberos::Ktadd["$ktadd"]
+}

--- a/manifests/host_ticket_cache.pp
+++ b/manifests/host_ticket_cache.pp
@@ -1,0 +1,26 @@
+# == Class: kerberos::host_ticket_cache
+#
+# Initialise a ticket cache for the host to be used especially by kadmin.
+#
+# === Authors
+#
+# Michael Weiser <michael.weiser@gmx.de>
+#
+
+class kerberos::host_ticket_cache (
+  $host_ticket_cache_ccname = $kerberos::host_ticket_cache_ccname,
+  $host_ticket_cache_service = $kerberos::host_ticket_cache_service,
+  $host_ticket_cache_principal = $kerberos::host_ticket_cache_principal,
+) inherits kerberos {
+  # if this is the KDC, then obviously the machine principals must be
+  # created first
+  Kerberos::Addprinc<| local == true |> ->
+    Kerberos::Ticket_cache["krb5-cache-puppet"]
+
+  kerberos::ticket_cache { "krb5-cache-puppet":
+    ccname    => $host_ticket_cache_ccname,
+    pkinit    => true,
+    principal => $host_ticket_cache_principal,
+    service   => $host_ticket_cache_service,
+  }
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -95,6 +95,11 @@
 # $kadmind_acls
 #   ACLs for for the admin service.
 #
+# $host_ticket_cache_ccname
+# $host_ticket_cache_service
+# $host_ticket_cache_principal
+#   When creating a ticket cache for use by kadmin use these parameters.
+#
 # $pkinit_packages
 # $client_packages
 # $kdc_server_packages
@@ -164,6 +169,10 @@ class kerberos(
 
   $kadmind_enable = true,
   $kadmind_acls = { "*/admin@$realm" => '*' },
+
+  $host_ticket_cache_ccname = "/tmp/krb5cc.puppet",
+  $host_ticket_cache_service = "kadmin/admin",
+  $host_ticket_cache_principal = $fqdn,
 
   # packages
   $pkinit_packages = $kerberos::params::pkinit_packages,


### PR DESCRIPTION
Add new types to shortcut adding a principal to the KDC, creating a
keytab and adding the principal's keys to it and create a host ticket
cache. The latter currently only supports pkinit assuming PKINIT-ready
puppet certificates (see:
https://github.com/puppetlabs/puppet/pull/3614,
https://tickets.puppetlabs.com/browse/PUP-4014).