### PR TITLE
Add replication support

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ following classes:
 
     kerberos::client
     kerberos::kdc::master
+    kerberos::kdc::slave
 
 
 It is best to store passwords in Hiera; that way, you can have a set of test

--- a/manifests/kdc/master.pp
+++ b/manifests/kdc/master.pp
@@ -1,7 +1,8 @@
 # === Class: kerberos::kdc::master
 #
 # Kerberos master kdc: Sets up the server daemons using kerberos::server::kdc
-# and kerberos::server::kadmind classes.
+# and kerberos::server::kadmind classes. Creates the master database and adds a
+# cron job for updating the slaves.
 #
 # === Authors
 #
@@ -16,6 +17,7 @@
 #
 class kerberos::kdc::master (
   $kadmind_enable = $kerberos::kadmind_enable,
+  $kdc_slaves = $kerberos::kdc_slaves,
   $kdc_database_password = $kerberos::kdc_database_password,
   $kdc_principals = $kerberos::kdc_principals,
   $kdc_trusted_realms = $kerberos::kdc_trusted_realms,
@@ -28,6 +30,11 @@ class kerberos::kdc::master (
   # convenience setting for enabling and disabling kadmind
   if $kadmind_enable {
     include kerberos::server::kadmind
+  }
+
+  # set up kprop cron job if we have slaves
+  if $kdc_slaves {
+    include kerberos::server::kprop
   }
 
   if $kdc_database_password {

--- a/manifests/kdc/slave.pp
+++ b/manifests/kdc/slave.pp
@@ -1,0 +1,54 @@
+# === Class: kerberos::kdc::slave
+#
+# Kerberos slave KDC: Sets up the server daemons using kerberos::server::kdc
+# and kerberos::server::kpropd classes.
+#
+# === Authors
+#
+# Jason Edgecombe <jason@rampaginggeek.com>
+#
+# Additions by <greg.1.anderson@greeknowe.org>
+# Additions by Michael Weiser <michael.weiser@gmx.de>
+#
+# === Copyright
+#
+# Copyright 2013 Jason Edgecombe, unless otherwise noted.
+#
+class kerberos::kdc::slave (
+  $kdc_slaves = $kerberos::kdc_slaves,
+  $kdc_database_path = $kerberos::kdc_database_path,
+  $kdc_database_password = $kerberos::kdc_database_password,
+  $kdc_stash_path = $kerberos::kdc_stash_path,
+) inherits kerberos {
+  # at a minimum a slave has krb5kdc and kpropd server
+  include kerberos::server::kdc
+  include kerberos::server::kpropd
+
+  # set up kprop cron job if we have slaves
+  if $kdc_slaves {
+    include kerberos::server::kprop
+  }
+
+  if $kdc_database_password {
+    $db_password = $kdc_database_password
+  } else {
+    $db_password = fail('kdc_data_password must be set')
+  }
+
+  # funky: Wait for someone to create our database before starting the KDC. In
+  # this case that someone is kpropd. Should only ever cause a real wait if
+  # we're bootstrapping and the database doesn't exist yet.
+  Service['kpropd'] ->
+  exec { 'krb5-wait-for-database':
+    command   => "test -f '$kdc_database_path'",
+    path      => [ '/bin', '/usr/bin' ],
+    tries     => 10,
+    try_sleep => 30,
+  } ->
+  exec { 'krb5-stash-database-pw':
+    command => "echo '${db_password}' | ${kdb5_util_path} stash",
+    path => [ '/bin', '/usr/bin', '/sbin', '/usr/sbin' ],
+    creates => $kdc_stash_path,
+  } ~>
+  Service['krb5kdc']
+}

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -13,7 +13,6 @@
 # Copyright 2013 Jason Edgecombe, unless otherwise noted.
 #
 class kerberos::params {
-
   case $::operatingsystem {
     Ubuntu, Debian: {
       $client_packages    = [ 'krb5-user' ]
@@ -23,10 +22,14 @@ class kerberos::params {
 
       $kdc_service_name       = 'krb5-kdc'
       $kadmin_service_name    = 'krb5-admin-server'
+      $kpropd_service_name    = 'krb5-kpropd'
 
       $krb5_conf_path         = '/etc/krb5.conf'
       $kdc_conf_path          = '/etc/krb5kdc/kdc.conf'
       $kadm5_acl_path         = '/etc/krb5kdc/kadm5.acl'
+      $kpropd_acl_path        = '/etc/krb5kdc/kpropd.acl'
+      $kprop_cron_path        = '/etc/krb5kdc/kprop.cron'
+      $kprop_path             = '/usr/sbin/kprop'
       $kdb5_util_path         = '/usr/sbin/kdb5_util'
 
       $kdc_database_path      = '/var/lib/krb5kdc/principal'

--- a/manifests/server/kadmind.pp
+++ b/manifests/server/kadmind.pp
@@ -14,17 +14,11 @@
 # Copyright 2013 Jason Edgecombe, unless otherwise noted.
 #
 class kerberos::server::kadmind (
-  $kadmin_server_packages = $kerberos::kadmin_server_packages,
   $kadm5_acl_path = $kerberos::kadm5_acl_path,
   $kadmind_acls = $kerberos::kadmind_acls,
   $kadmin_service_name = $kerberos::kadmin_service_name,
 ) inherits kerberos {
-  include kerberos::server::base
-
-  package { 'krb5-kadmind-server-packages' :
-    ensure => present,
-    name   => $kadmin_server_packages,
-  }
+  include kerberos::server::kadmind_kprop
 
   require stdlib
   $kadm5_acl_dir = dirname($kadm5_acl_path)

--- a/manifests/server/kadmind_kprop.pp
+++ b/manifests/server/kadmind_kprop.pp
@@ -1,0 +1,28 @@
+# === Class: kerberos::server::kadmind_kprop
+#
+# Kerberos KDC kadmin and kpropd common elements: Installs kadmind packages
+# which also contain kprop.
+#
+# === Authors
+#
+# Author Name <jason@rampaginggeek.com>
+#
+# Additions by <greg.1.anderson@greeknowe.org>
+# Additions by Michael Weiser <michael.weiser@gmx.de>
+#
+# === Copyright
+#
+# Copyright 2013 Jason Edgecombe, unless otherwise noted.
+#
+class kerberos::server::kadmind_kprop (
+  $kadmin_server_packages = $kerberos::kadmin_server_packages,
+) inherits kerberos {
+  # kadmind and kprop both only make sense on a master KDC. So pull in
+  # general common server config for KDCs.
+  include kerberos::server::base
+
+  package { 'krb5-kadmind-server-packages':
+    ensure => present,
+    name   => $kadmin_server_packages,
+  }
+}

--- a/manifests/server/kdc.pp
+++ b/manifests/server/kdc.pp
@@ -2,8 +2,8 @@
 #
 # Kerberos kdc service. Installs and starts the KDC service. Uses
 # kerberos::server::base to create kdc.conf. Although it starts the service
-# it does not create a database. Use kerberos::kdc::master
-# to actually set up functioning KDCs.
+# it does not create a database. Use kerberos::kdc::master or
+# kerberos::kdc:slave to actually set up functioning KDCs.
 #
 # === Authors
 #

--- a/manifests/server/kprop.pp
+++ b/manifests/server/kprop.pp
@@ -1,0 +1,81 @@
+# === Class: kerberos::server::kprop
+#
+# Kerberos kprop program: Adds a cron job for updating the slave servers.
+#
+# === Authors
+#
+# Jason Edgecombe <jason@rampaginggeek.com>
+#
+# Additions by <greg.1.anderson@greeknowe.org>
+# Additions by Michael Weiser <michael.weiser@gmx.de>
+#
+# === Copyright
+#
+# Copyright 2013 Jason Edgecombe, unless otherwise noted.
+#
+class kerberos::server::kprop (
+  $kprop_cron_path = $kerberos::kprop_cron_path,
+  $kprop_cron_hour = $kprop_cron_hour,
+  $kprop_cron_minute = $kerberos::kprop_cron_minute,
+  $kprop_keytab = $kerberos::kprop_keytab,
+  $kprop_principal = $kerberos::kprop_principal,
+
+  $kdc_slaves = $kerberos::kdc_slaves,
+  $kdc_database_path = $kerberos::kdc_database_path,
+  $kprop_path = $kerberos::kprop_path,
+  $kdb5_util_path = $kerberos::kdb5_util_path,
+
+  $pkinit_anchors = $kerberos::pkinit_anchors,
+  $host_ticket_cache_ccname = $kerberos::host_ticket_cache_ccname,
+
+  # facter fact
+  $kerberos_bootstrap = $::kerberos_bootstrap,
+) inherits kerberos {
+  include kerberos::server::kadmind_kprop
+
+  # if we have pkinit we can automatically create the keytab for kprop
+  $ktadd = "${kprop_keytab}@${kprop_principal}"
+  if $pkinit_anchors and !defined(Kerberos::Addprinc_keytab_ktadd[$ktadd]) {
+    kerberos::addprinc_keytab_ktadd { $ktadd:
+      local => false,
+      kadmin_ccache => $host_ticket_cache_ccname,
+    } -> Cron['kprop']
+  }
+
+  require stdlib
+  # needed in the kprop template
+  $kdc_database_dir = dirname($kdc_database_path)
+
+  $kprop_cron_dir = dirname($kprop_cron_path)
+  if !defined(File[$kprop_cron_dir]) {
+    file { $kprop_cron_dir: ensure => directory }
+  }
+
+  file { 'kprop.cron':
+    ensure  => file,
+    path    => $kprop_cron_path,
+    content => template('kerberos/kprop.cron.erb'),
+    mode    => '0755',
+    owner   => 0,
+    group   => 0,
+    require => File[$kprop_cron_dir],
+  }
+
+  cron { 'kprop':
+    command => $kprop_cron_path,
+    user    => 'root',
+    hour    => $kprop_cron_hour,
+    minute  => $kprop_cron_minute,
+  }
+
+  if $kerberos_bootstrap {
+    exec { 'kprop-force':
+      command   => $kprop_cron_path,
+      user      => 'root',
+      tries     => 30,
+      try_sleep => 10,
+      # you can't do a bootstrap without a keytab for kprop
+      require   => Kerberos::Ktadd[$ktadd]
+    }
+  }
+}

--- a/manifests/server/kpropd.pp
+++ b/manifests/server/kpropd.pp
@@ -1,0 +1,61 @@
+# === Class: kerberos::server::kpropd
+#
+# Kerberos kpropd service. Installs and starts the kpropd service on a slave KDC.
+#
+# === Authors
+#
+# Author Name <jason@rampaginggeek.com>
+# Additions by Michael Weiser <michael.weiser@gmx.de>
+#
+# === Copyright
+#
+# Copyright 2013 Jason Edgecombe, unless otherwise noted.
+#
+class kerberos::server::kpropd (
+  $kpropd_acl_path = $kerberos::kpropd_acl_path,
+  $kpropd_master_principal = $kerberos::kpropd_master_principal_cfg,
+  $kpropd_service_name = $kerberos::kpropd_service_name,
+  $kpropd_keytab = $kerberos::kpropd_keytab,
+  $kpropd_principal = $kerberos::kpropd_principal,
+
+  $pkinit_anchors = $kerberos::pkinit_anchors,
+  $host_ticket_cache_ccname = $kerberos::host_ticket_cache_ccname,
+
+  # facter fact
+  $kerberos_bootstrap = $::kerberos_bootstrap,
+) inherits kerberos::params {
+  include kerberos::server::kdc
+
+  # if we have pkinit we can automatically create the keytab
+  $ktadd = "${kpropd_keytab}@${kpropd_principal}"
+  if $pkinit_anchors and !defined(Kerberos::Addprinc_keytab_ktadd[$ktadd]) {
+    kerberos::addprinc_keytab_ktadd { $ktadd:
+      local => false,
+      kadmin_ccache => $host_ticket_cache_ccname,
+      # if we're bootstrapping the master might not be up yet and even if not
+      # it might just be rebooting
+      kadmin_tries => 30,
+      kadmin_try_sleep => $kerberos_bootstrap ? { '1' => 60, default => 10 },
+    } -> Service['kpropd']
+  }
+
+  file { 'kpropd.acl':
+    ensure  => file,
+    path    => $kpropd_acl_path,
+    content => template('kerberos/kpropd.acl.erb'),
+    mode    => '0600',
+    owner   => 0,
+    group   => 0,
+  }
+
+  service { 'kpropd':
+    name       => $kpropd_service_name,
+    ensure     => running,
+    enable     => true,
+    hasrestart => true,
+    hasstatus  => true,
+    subscribe  => File['kdc.conf', 'kpropd.acl', $kpropd_keytab],
+    # kpropd needs its keytab to work
+    require    => Kerberos::Ktadd[$ktadd]
+  }
+}

--- a/templates/kdc.conf.erb
+++ b/templates/kdc.conf.erb
@@ -17,6 +17,15 @@
 <% if @pkinit_anchors -%>
         pkinit_anchors = <%= @pkinit_anchors %>
 <% end -%>
+<% if @kdc_iprop_port -%>
+        iprop_port = <%= @kdc_iprop_port %>
+<% end -%>
+<% if @kdc_iprop_logfile -%>
+        iprop_logfile = <%= @kdc_iprop_logfile %>
+<% end -%>
+<% if @kdc_iprop_resync_timeout -%>
+        iprop_resync_timeout = <%= @kdc_iprop_resync_timeout %>
+<% end -%>
     }
 
 [logging]

--- a/templates/kprop.cron.erb
+++ b/templates/kprop.cron.erb
@@ -1,0 +1,14 @@
+#!/bin/sh
+RC=0
+DUMP="<%= @kdc_database_dir %>/kdb_dump"
+<%= @kdb5_util_path %> dump "$DUMP"
+<% @kdc_slaves.each do |slave| -%>
+
+<%= @kprop_path %> -f "$DUMP" <%= slave %>
+if [ $? != 0 ]; then
+  /usr/bin/logger "`basename $0`: failed to replicate krb5 database to <%= slave %>"
+  RC=1
+fi
+<% end -%>
+
+exit $RC

--- a/templates/kpropd.acl.erb
+++ b/templates/kpropd.acl.erb
@@ -1,0 +1,1 @@
+<%= @kpropd_master_principal %>


### PR DESCRIPTION
Hi Jason,

here's replication support. I tried to anticipate all lint niggles this time.

Support replication through a kprop cron job on the master and running
kpropd on the slave. For that add new server components kprop and
kpropd. Separate out common requirements for kadmind and kprop. Add a
new KDC role kerberos::kdc::slave. Add configuration options for
incremental replication (atm untested though).