### PR TITLE
Fix up KDC database password error

### DIFF
--- a/manifests/kdc/master.pp
+++ b/manifests/kdc/master.pp
@@ -37,14 +37,12 @@ class kerberos::kdc::master (
     include kerberos::server::kprop
   }
 
-  if $kdc_database_password {
-    $db_password = $kdc_database_password
-  } else {
-    $db_password = fail('kdc_data_password must be set')
+  if ! $kdc_database_password {
+    fail('kdc_database_password must be set')
   }
 
   exec { 'create_krb5kdc_principal':
-    command => "${kdb5_util_path} -r ${realm} -P \'${db_password}\' create -s",
+    command => "${kdb5_util_path} -r ${realm} -P \'${kdc_database_password}\' create -s",
     creates => $kdc_database_path,
     require => [ File['krb5-kdc-database-dir', 'kdc.conf'], ],
   }

--- a/manifests/kdc/slave.pp
+++ b/manifests/kdc/slave.pp
@@ -29,10 +29,8 @@ class kerberos::kdc::slave (
     include kerberos::server::kprop
   }
 
-  if $kdc_database_password {
-    $db_password = $kdc_database_password
-  } else {
-    $db_password = fail('kdc_data_password must be set')
+  if ! $kdc_database_password {
+    fail('kdc_database_password must be set')
   }
 
   # funky: Wait for someone to create our database before starting the KDC. In
@@ -46,7 +44,7 @@ class kerberos::kdc::slave (
     try_sleep => 30,
   } ->
   exec { 'krb5-stash-database-pw':
-    command => "echo '${db_password}' | ${kdb5_util_path} stash",
+    command => "echo '${kdc_database_password}' | ${kdb5_util_path} stash",
     path => [ '/bin', '/usr/bin', '/sbin', '/usr/sbin' ],
     creates => $kdc_stash_path,
   } ~>


### PR DESCRIPTION
Hi Jason,

I have a couple more minor fixes and enhancements for you. Also, I took your advice and wrote a custom hiera backend for trocla for generation of the kdc database password. Have a look at https://github.com/duritong/puppet-trocla/pull/15 if you're interested.

Avoid error message 'Error: Could not retrieve catalog from remote server:
Error 400 on SERVER: Function 'fail' does not return a value at
/etc/puppet/modules/kerberos/manifests/kdc/master.pp:41 on node ...'.

With this change it to correctly aborts with 'Error 400 on SERVER:
kdc_database_password must be set at
/etc/puppet/modules/kerberos/manifests/kdc/master.pp:41 on node ...'.