### PR TITLE
Make addprinc resilient to KDC unavailability

### DIFF
--- a/manifests/ticket_cache.pp
+++ b/manifests/ticket_cache.pp
@@ -13,7 +13,11 @@ define kerberos::ticket_cache ($ccname = $title,
     $service = undef,
     $pkinit = false,
     $pkinit_cert = "/var/lib/puppet/ssl/certs/${::fqdn}.pem",
-    $pkinit_key = "/var/lib/puppet/ssl/private_keys/${::fqdn}.pem") {
+    $pkinit_key = "/var/lib/puppet/ssl/private_keys/${::fqdn}.pem",
+
+    # facter fact
+    $kerberos_bootstrap = $::kerberos_bootstrap,
+) {
   # this needs to be a client in order to run kinit and kadmin
   include kerberos::client
 
@@ -39,5 +43,9 @@ define kerberos::ticket_cache ($ccname = $title,
     require => [ Package['krb5-client-packages'], File['krb5.conf'] ],
     # always recreate (for now) to avoid expired tickets
     # creates => $ccname
+    # if we're bootstrapping no KDC might be up yet and even if not
+    # it might just be rebooting
+    tries => 30,
+    try_sleep => $kerberos_bootstrap ? { '1' => 60, default => 10 },
   }
 }


### PR DESCRIPTION
Retry addprinc a few times in case the master KDC is just rebooting.
Also expand the wait interval if we're bootstrapping.