### PR TITLE
Silence puppet deprecation warning in krb5.conf.erb

### DIFF
--- a/templates/krb5.conf.erb
+++ b/templates/krb5.conf.erb
@@ -32,6 +32,6 @@
         }
 
 [domain_realm]
-<% domain_realm_list.each_pair do |key, val| -%>
+<% @domain_realm_list.each_pair do |key, val| -%>
         <%= key %> = <%= val %>
 <% end -%>


### PR DESCRIPTION
Silence quite loud puppet deprecation warning:

Warning: Variable access via 'domain_realm_list' is deprecated. Use
'@domain_realm_list' instead.
template[/usr/share/puppet/modules/kerberos/templates/krb5.conf.erb]:35
(at /usr/lib/ruby/vendor_ruby/puppet/parser/templatewrapper.rb:76:in
`method_missing')