### PR TITLE
Fix unmet dependency if dirname($kdc_database_path) == dirname($kdc_conf_path)

### DIFF
--- a/manifests/addprinc.pp
+++ b/manifests/addprinc.pp
@@ -16,6 +16,7 @@ define kerberos::addprinc($principal_name = $title,
   $password = undef, $flags = '',
   $local = true, $kadmin_ccache = undef, $keytab = undef,
   $tries = undef, $try_sleep = undef,
+  $kadmin_server_packages = $kerberos::kadmin_server_packages,
 ) {
   if $local {
     # if we're gonna run kadmin.local we better make sure it's
@@ -24,7 +25,7 @@ define kerberos::addprinc($principal_name = $title,
     $kadmin = 'kadmin.local'
 
     $addprinc_exec_require = [
-                              Package['krb5-kadmind-server-packages'],
+                              Package[$kadmin_server_packages],
                               Exec['create_krb5kdc_principal']
                               ]
   } else {

--- a/manifests/addprinc.pp
+++ b/manifests/addprinc.pp
@@ -49,9 +49,11 @@ define kerberos::addprinc($principal_name = $title,
                               ]
   }
 
-  $password_par = $password ? {
-    undef => '-nokey',
-    default => "-pw ${password}"
+  if !("-randkey" in $flags) {
+    $password_par = $password ? {
+      undef => '-nokey',
+      default => "-pw ${password}"
+    }
   }
 
   $cmd = "addprinc ${flags} ${password_par} ${principal_name}"

--- a/manifests/kdc/master.pp
+++ b/manifests/kdc/master.pp
@@ -47,7 +47,7 @@ class kerberos::kdc::master (
   exec { 'create_krb5kdc_principal':
     command => "${kdb5_util_path} -r ${realm} -P \'${kdc_database_password}\' create -s",
     creates => $kdc_database_path,
-    require => [ File['krb5-kdc-database-dir', 'kdc.conf'], ],
+    require => [ File[dirname($kdc_database_path), 'kdc.conf'], ],
   }
 
   # Look up our users in hiera. Create a principal for each one listed

--- a/manifests/ktadd.pp
+++ b/manifests/ktadd.pp
@@ -18,6 +18,7 @@ define kerberos::ktadd(
   $kadmin_tries = undef, $kadmin_try_sleep = undef,
   $kadmin_server_package = $kerberos::kadmin_server_package,
   $client_packages = $kerberos::client_packages,
+  $realm = $kerberos::realm,
 ) {
   $ktadd = "ktadd_${keytab}_${principal}"
   if $local {
@@ -44,7 +45,7 @@ define kerberos::ktadd(
   if $reexport {
     $unless = undef
   } else {
-    $unless = "klist -k '${keytab}' | grep ' ${principal}@'"
+    $unless = "klist -k '${keytab}' | grep ' ${principal}@${realm}'"
   }
 
   $cmd = "ktadd -k ${keytab} ${principal}"

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -16,8 +16,8 @@ class kerberos::params {
   case $::osfamily {
     'Debian': {
       $client_packages    = [ 'krb5-user' ]
-      $kdc_server_packages    = [ 'krb5-kdc' ]
-      $kadmin_server_packages = [ 'krb5-admin-server' ]
+      $kdc_server_package     = 'krb5-kdc'
+      $kadmin_server_package  = 'krb5-admin-server'
       $pkinit_packages        = [ 'krb5-pkinit' ]
 
       $kdc_service_name       = 'krb5-kdc'
@@ -39,8 +39,8 @@ class kerberos::params {
     }
     'RedHat': {
       $client_packages    = [ 'krb5-workstation' ]
-      $kdc_server_packages    = [ 'krb5-server' ]
-      $kadmin_server_packages = [ 'krb5-server' ]
+      $kdc_server_package     = 'krb5-server'
+      $kadmin_server_package  = 'krb5-server'
       $pkinit_packages        = [ 'krb5-pkinit-openssl' ]
 
       $kdc_service_name       = 'krb5kdc'

--- a/templates/kprop.cron.erb
+++ b/templates/kprop.cron.erb
@@ -3,10 +3,10 @@
 # Do NOT manually edit this file.
 RC=0
 DUMP="<%= @kdc_database_dir %>/kdb_dump"
-<%= @kdb5_util_path %> dump "$DUMP"
+<%= @kdb5_util_path %> -r <%= @realm %> dump "$DUMP"
 <% @kdc_slaves.each do |slave| -%>
 
-<%= @kprop_path %> -f "$DUMP" <%= slave %>
+<%= @kprop_path %> -r <%= @realm %> -f "$DUMP" <%= slave %>
 if [ $? != 0 ]; then
   /usr/bin/logger "`basename $0`: failed to replicate krb5 database to <%= slave %>"
   RC=1


### PR DESCRIPTION
In case of RedHat defaults for the kdc config and the kdc database pointing to the same directory (/var/kerberos/krb5kdc)

If this happens following error ocures:

Error: Could not find dependency File[krb5-kdc-database-dir] for Exec[create_krb5kdc_principal] at /opt/puppet/modules/kerberos/manifests/kdc/master.pp:52

Because: File[$kdc_database_dir] already exists ( via the requirement in base.pp File[$kdc_conf_dir] )
	the dependency krb5-kdc-database-dir will not be fulfillable

But I think the real requirement for create_krb5kdc_principal is not the existing krb5-kdc-database-dir (which is actually the database itself) but it should be the directory in which the database is created.

This works for me, but please double check if I’m right.