### PR TITLE
Fix up creation of and dependencies on database directory

### DIFF
--- a/manifests/kdc/master.pp
+++ b/manifests/kdc/master.pp
@@ -44,10 +44,13 @@ class kerberos::kdc::master (
     fail('kdc_database_password must be set')
   }
 
+  require stdlib
+  $kdc_database_dir = dirname($kdc_database_path)
+
   exec { 'create_krb5kdc_principal':
     command => "${kdb5_util_path} -r ${realm} -P \'${kdc_database_password}\' create -s",
     creates => $kdc_database_path,
-    require => [ File['krb5-kdc-database-dir', 'kdc.conf'], ],
+    require => [ File[$kdc_database_dir, 'kdc.conf'], ],
   }
 
   # Look up our users in hiera. Create a principal for each one listed

--- a/manifests/server/kdc.pp
+++ b/manifests/server/kdc.pp
@@ -40,11 +40,7 @@ class kerberos::server::kdc (
   if !defined(File[$kdc_database_dir]) {
     # title used by master.pp to require dir before creating
     # database
-    file { 'krb5-kdc-database-dir':
-      ensure => 'directory',
-      path   => $kdc_database_dir,
-      mode   => '0700',
-    }
+    file { $kdc_database_dir: ensure => 'directory' }
   }
 
   service { 'krb5kdc':

--- a/manifests/server/kpropd.pp
+++ b/manifests/server/kpropd.pp
@@ -13,6 +13,8 @@
 # Copyright 2013 Jason Edgecombe, unless otherwise noted.
 #
 class kerberos::server::kpropd (
+  $kdc_database_path = $kerberos::kdc_database_path,
+
   $kpropd_acl_path = $kerberos::kpropd_acl_path,
   $kpropd_master_principal = $kerberos::kpropd_master_principal_cfg,
   $kpropd_service_name = $kerberos::kpropd_service_name,
@@ -55,6 +57,9 @@ class kerberos::server::kpropd (
     group   => 0,
   }
 
+  require stdlib
+  $kdc_database_dir = dirname($kdc_database_path)
+
   service { 'kpropd':
     ensure     => running,
     name       => $kpropd_service_name,
@@ -63,6 +68,6 @@ class kerberos::server::kpropd (
     hasstatus  => true,
     subscribe  => File['kdc.conf', 'kpropd.acl', $kpropd_keytab],
     # kpropd needs its keytab to work
-    require    => Kerberos::Ktadd[$ktadd]
+    require    => [ Kerberos::Ktadd[$ktadd], File[$kdc_database_dir] ]
   }
 }


### PR DESCRIPTION
Refer to the database directory by path instead of title because it was
done inconsistently before and the path might be the same as the
kdc_conf_dir and the collision can not be detected and avoided
otherwise.

Do not force a mode of 0700 because it's not necessary (the KDC secures
file individual files' modes itself) and might cause flapping depending
on which file resource (kdc_conf_dir or kdc_database_dir) "wins", i.e.
is instantiated.

Make kpropd depend on the database directory as well because it does
actually need it to exist in order to be able to put the just replicated
database into it.