### PR TITLE
Rework package dependencies

### DIFF
--- a/manifests/addprinc.pp
+++ b/manifests/addprinc.pp
@@ -16,6 +16,8 @@ define kerberos::addprinc($principal_name = $title,
   $password = undef, $flags = '',
   $local = true, $kadmin_ccache = undef, $keytab = undef,
   $tries = undef, $try_sleep = undef,
+  $kadmin_server_package = $kerberos::kadmin_server_package,
+  $client_packages = $kerberos::client_packages,
 ) {
   if $local {
     # if we're gonna run kadmin.local we better make sure it's
@@ -24,7 +26,7 @@ define kerberos::addprinc($principal_name = $title,
     $kadmin = 'kadmin.local'
 
     $addprinc_exec_require = [
-                              Package['krb5-kadmind-server-packages'],
+                              Package[$kadmin_server_package],
                               Exec['create_krb5kdc_principal']
                               ]
   } else {
@@ -44,7 +46,7 @@ define kerberos::addprinc($principal_name = $title,
     }
 
     $addprinc_exec_require = [
-                              Package['krb5-client-packages'],
+                              Package[$client_packages],
                               File['krb5.conf']
                               ]
   }

--- a/manifests/base.pp
+++ b/manifests/base.pp
@@ -14,9 +14,9 @@ class kerberos::base (
   $pkinit_packages = $kerberos::pkinit_packages,
 ) inherits kerberos {
   if $pkinit_anchors {
-    package { 'krb5-pkinit-packages':
+    package { $pkinit_packages:
       ensure => present,
-      name   => $pkinit_packages,
+      tag    => 'krb5-pkinit-packages',
     }
   }
 }

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -38,9 +38,8 @@ class kerberos::client (
     $domain_realm_list = $domain_realm
   }
 
-  package { 'krb5-client-packages' :
+  package { $client_packages:
     ensure => present,
-    name   => $client_packages,
     before => File['krb5.conf'],
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -142,9 +142,8 @@
 #
 # $pkinit_packages
 # $client_packages
-# $kdc_server_packages
-# $kadmin_server_packages
-# $kpropd_server_packages
+# $kdc_server_package
+# $kadmin_server_package
 #   Package names.
 #
 # $kdc_service_name
@@ -239,9 +238,8 @@ class kerberos(
   # packages
   $pkinit_packages = $kerberos::params::pkinit_packages,
   $client_packages = $kerberos::params::client_packages,
-  $kdc_server_packages = $kerberos::params::kdc_server_packages,
-  $kadmin_server_packages = $kerberos::params::kadmin_server_packages,
-  $kpropd_server_packages = $kerberos::params::kpropd_server_packages,
+  $kdc_server_package = $kerberos::params::kdc_server_package,
+  $kadmin_server_package = $kerberos::params::kadmin_server_package,
 
   # service names
   $kdc_service_name = $kerberos::params::kdc_service_name,

--- a/manifests/ktadd.pp
+++ b/manifests/ktadd.pp
@@ -16,11 +16,13 @@ define kerberos::ktadd(
   $local = true, $reexport = false,
   $kadmin_ccache = undef, $kadmin_keytab = undef,
   $kadmin_tries = undef, $kadmin_try_sleep = undef,
+  $kadmin_server_package = $kerberos::kadmin_server_package,
+  $client_packages = $kerberos::client_packages,
 ) {
   $ktadd = "ktadd_${keytab}_${principal}"
   if $local {
     $kadmin = 'kadmin.local'
-    Package['krb5-kadmind-server-packages'] -> Exec[$ktadd]
+    Package[$kadmin_server_package] -> Exec[$ktadd]
     Exec['create_krb5kdc_principal'] -> Exec[$ktadd]
   } else {
     $kadmin = 'kadmin'
@@ -35,7 +37,7 @@ define kerberos::ktadd(
       default => "-k '${kadmin_keytab}'"
     }
 
-    Package['krb5-client-packages'] -> Exec[$ktadd]
+    Package[$client_packages] -> Exec[$ktadd]
     File['krb5.conf'] -> Exec[$ktadd]
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -15,9 +15,9 @@
 class kerberos::params {
   case $::operatingsystem {
     Ubuntu, Debian: {
-      $client_packages    = [ 'krb5-user' ]
-      $kdc_server_packages    = [ 'krb5-kdc' ]
-      $kadmin_server_packages = [ 'krb5-admin-server' ]
+      $client_packages        = [ 'krb5-user' ]
+      $kdc_server_package     = 'krb5-kdc'
+      $kadmin_server_package  = 'krb5-admin-server'
       $pkinit_packages        = [ 'krb5-pkinit' ]
 
       $kdc_service_name       = 'krb5-kdc'
@@ -38,9 +38,9 @@ class kerberos::params {
       $kadmind_logfile        = '/var/log/kerberos_admin_server.log'
     }
     RedHat: {
-      $client_packages    = [ 'krb5-workstation' ]
-      $kdc_server_packages    = [ 'krb5-server' ]
-      $kadmin_server_packages = [ 'krb5-server' ]
+      $client_packages        = [ 'krb5-workstation' ]
+      $kdc_server_package     = 'krb5-server'
+      $kadmin_server_package  = 'krb5-server'
       $pkinit_packages        = [ 'krb5-pkinit-openssl' ]
 
       $kdc_service_name       = 'krb5kdc'

--- a/manifests/server/kadmind_kprop.pp
+++ b/manifests/server/kadmind_kprop.pp
@@ -15,16 +15,15 @@
 # Copyright 2013 Jason Edgecombe, unless otherwise noted.
 #
 class kerberos::server::kadmind_kprop (
-  $kadmin_server_packages = $kerberos::kadmin_server_packages,
+  $kadmin_server_package = $kerberos::kadmin_server_package,
 ) inherits kerberos {
   # kadmind and kprop both only make sense on a master KDC. So pull in
   # general common server config for KDCs.
   include kerberos::server::base
 
-  if (!defined(Package[$kadmin_server_packages])) {
-    package { 'krb5-kadmind-server-packages':
+  if (!defined(Package[$kadmin_server_package])) {
+    package { $kadmin_server_package:
       ensure => present,
-      name   => $kadmin_server_packages,
     }
   }
 }

--- a/manifests/server/kdc.pp
+++ b/manifests/server/kdc.pp
@@ -18,7 +18,7 @@
 #
 class kerberos::server::kdc (
   $kdc_database_path = $kerberos::kdc_database_path,
-  $kdc_server_packages = $kerberos::kdc_server_packages,
+  $kdc_server_package = $kerberos::kdc_server_package,
   $kdc_service_name = $kerberos::kdc_service_name,
 ) inherits kerberos {
   # pkinit packages
@@ -26,10 +26,9 @@ class kerberos::server::kdc (
   # kdc.conf
   include kerberos::server::base
 
-  if (!defined(Package[$kdc_server_packages])) {
-    package { 'krb5-kdc-server-packages' :
+  if (!defined(Package[$kdc_server_package])) {
+    package { $kdc_server_package:
       ensure => present,
-      name   => $kdc_server_packages,
       before => File['kdc.conf'],
     }
   }
@@ -62,5 +61,5 @@ class kerberos::server::kdc (
   Kerberos::Addprinc<| local == true |> -> Service['krb5kdc']
 
   # installed in kerberos::base if enabled
-  Package<| title == 'krb5-pkinit-packages' |> -> Service['krb5kdc']
+  Package<| tag == 'krb5-pkinit-packages' |> -> Service['krb5kdc']
 }

--- a/manifests/ticket_cache.pp
+++ b/manifests/ticket_cache.pp
@@ -15,6 +15,8 @@ define kerberos::ticket_cache ($ccname = $title,
     $pkinit_cert = "/var/lib/puppet/ssl/certs/${::fqdn}.pem",
     $pkinit_key = "/var/lib/puppet/ssl/private_keys/${::fqdn}.pem",
 
+    $client_packages = $kerberos::client_packages,
+
     # facter fact
     $kerberos_bootstrap = $::kerberos_bootstrap,
 ) {
@@ -45,7 +47,7 @@ define kerberos::ticket_cache ($ccname = $title,
   exec { "ticket_cache_${title}":
     command   => "${kinit_cmd} ${principal}",
     path      => '/usr/bin',
-    require   => [ Package['krb5-client-packages'], File['krb5.conf'] ],
+    require   => [ Package[$client_packages], File['krb5.conf'] ],
     # always recreate (for now) to avoid expired tickets
     # creates => $ccname
     # if we're bootstrapping no KDC might be up yet and even if not


### PR DESCRIPTION
Depend on packages by name instead of descriptive title. Use tags where
possible. Use arrays of package names where not. Drop the arrays if
checks using defined are necessary to avoid collisions.

Drop unused $kpropd_server_packages variable.