### PR TITLE
function 'defined' called with mis-matched arguments

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -44,9 +44,7 @@ class kerberos::client (
   }
 
   $krb5_conf_dir = dirname($krb5_conf_path)
-  if !defined(File[$krb5_conf_dir]) {
-    file { $krb5_conf_dir: ensure => directory }
-  }
+  ensure_resource('file', $krb5_conf_dir, { ensure => 'directory' })
 
   file { 'krb5.conf':
     ensure  => file,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -15,9 +15,9 @@
 class kerberos::params {
   case $::osfamily {
     'Debian': {
-      $client_packages    = [ 'krb5-user' ]
-      $kdc_server_packages    = [ 'krb5-kdc' ]
-      $kadmin_server_packages = [ 'krb5-admin-server' ]
+      $client_packages        = [ 'krb5-user' ]
+      $kdc_server_package     = [ 'krb5-kdc' ]
+      $kadmin_server_package  = [ 'krb5-admin-server' ]
       $pkinit_packages        = [ 'krb5-pkinit' ]
 
       $kdc_service_name       = 'krb5-kdc'
@@ -38,9 +38,9 @@ class kerberos::params {
       $kadmind_logfile        = '/var/log/kerberos_admin_server.log'
     }
     'RedHat': {
-      $client_packages    = [ 'krb5-workstation' ]
-      $kdc_server_packages    = [ 'krb5-server' ]
-      $kadmin_server_packages = [ 'krb5-server' ]
+      $client_packages        = [ 'krb5-workstation' ]
+      $kdc_server_package     = [ 'krb5-server' ]
+      $kadmin_server_package  = [ 'krb5-server' ]
       $pkinit_packages        = [ 'krb5-pkinit-openssl' ]
 
       $kdc_service_name       = 'krb5kdc'

--- a/manifests/server/base.pp
+++ b/manifests/server/base.pp
@@ -31,9 +31,7 @@ class kerberos::server::base (
 ) inherits kerberos {
   require stdlib
   $kdc_conf_dir = dirname($kdc_conf_path)
-  if !defined(File[$kdc_conf_dir]) {
-    file { $kdc_conf_dir: ensure => 'directory' }
-  }
+  ensure_resource('file', $kdc_conf_dir, { ensure => 'directory' })
 
   file { 'kdc.conf':
     ensure  => file,

--- a/manifests/server/kadmind.pp
+++ b/manifests/server/kadmind.pp
@@ -22,9 +22,7 @@ class kerberos::server::kadmind (
 
   require stdlib
   $kadm5_acl_dir = dirname($kadm5_acl_path)
-  if !defined(File[$kadm5_acl_dir]) {
-    file { $kadm5_acl_dir: ensure => 'directory' }
-  }
+  ensure_resource( 'file', $kadm5_acl_dir, { ensure => 'directory' })
 
   file { 'kadm5.acl':
     ensure  => file,

--- a/manifests/server/kadmind_kprop.pp
+++ b/manifests/server/kadmind_kprop.pp
@@ -21,9 +21,5 @@ class kerberos::server::kadmind_kprop (
   # general common server config for KDCs.
   include kerberos::server::base
 
-  if (!defined(Package[$kadmin_server_package])) {
-    package { $kadmin_server_package:
-      ensure => present,
-    }
-  }
+  ensure_resource('package', $kadmin_server_package, { ensure => present })
 }

--- a/manifests/server/kdc.pp
+++ b/manifests/server/kdc.pp
@@ -26,21 +26,12 @@ class kerberos::server::kdc (
   # kdc.conf
   include kerberos::server::base
 
-  if (!defined(Package[$kdc_server_package])) {
-    package { $kdc_server_package:
-      ensure => present,
-      before => File['kdc.conf'],
-    }
-  }
+  ensure_resource('package', $kdc_server_package, { ensure => present, before => File['kdc.conf']})
 
   # is created here for both master and slave
   require stdlib
   $kdc_database_dir = dirname($kdc_database_path)
-  if !defined(File[$kdc_database_dir]) {
-    # title used by master.pp to require dir before creating
-    # database
-    file { $kdc_database_dir: ensure => 'directory' }
-  }
+  ensure_resource('file', $kdc_database_dir, { ensure => 'directory' })
 
   service { 'krb5kdc':
     ensure     => running,

--- a/manifests/server/kprop.pp
+++ b/manifests/server/kprop.pp
@@ -47,9 +47,7 @@ class kerberos::server::kprop (
   $kdc_database_dir = dirname($kdc_database_path)
 
   $kprop_cron_dir = dirname($kprop_cron_path)
-  if !defined(File[$kprop_cron_dir]) {
-    file { $kprop_cron_dir: ensure => directory }
-  }
+  ensure_resource('file', $kprop_cron_dir, { ensure => 'directory' })
 
   file { 'kprop.cron':
     ensure  => file,

--- a/manifests/server/kpropd.pp
+++ b/manifests/server/kpropd.pp
@@ -37,6 +37,10 @@ class kerberos::server::kpropd (
 
   # if we have pkinit we can automatically create the keytab
   $ktadd = "${kpropd_keytab}@${kpropd_principal}"
+
+  notify { "ktadd = ${kpropd_keytab}@${kpropd_principal}" : }
+  notify { "pkinit_anchors = ${pkinit_anchors}" : }
+
   if $pkinit_anchors and !defined(Kerberos::Addprinc_keytab_ktadd[$ktadd]) {
     kerberos::addprinc_keytab_ktadd { $ktadd:
       local            => false,


### PR DESCRIPTION
passing tupels into !defined() calls results in error 
move away from using !defined(Resource[]) in favor of stdlibs ensure_resource()
this does essentially the same job but doesn't get hung up when you pass it an array of resources

plus fixed var names in params