### PR TITLE
pass env KRB5_CONFIG to kinit and kadmin

### DIFF
--- a/manifests/addprinc.pp
+++ b/manifests/addprinc.pp
@@ -18,6 +18,7 @@ define kerberos::addprinc($principal_name = $title,
   $tries = undef, $try_sleep = undef,
   $kadmin_server_package = $kerberos::kadmin_server_package,
   $client_packages = $kerberos::client_packages,
+  $krb5_conf_path = $kerberos::krb5_conf_path,
 ) {
   if $local {
     # if we're gonna run kadmin.local we better make sure it's
@@ -60,10 +61,11 @@ define kerberos::addprinc($principal_name = $title,
 
   $cmd = "addprinc ${flags} ${password_par} ${principal_name}"
   exec { "add_principal_${principal_name}":
-    command   => "${kadmin} ${ccache_par} ${keytab_par} -q '${cmd}'",
-    path      => [ '/usr/sbin', '/usr/bin' ],
-    require   => $addprinc_exec_require,
-    tries     => $kerberos::kadmin_tries,
-    try_sleep => $kerberos::kadmin_try_sleep,
+    command     => "${kadmin} ${ccache_par} ${keytab_par} -q '${cmd}'",
+    path        => [ '/usr/sbin', '/usr/bin' ],
+    environment => "KRB5_CONFIG=${krb5_conf_path}",
+    require     => $addprinc_exec_require,
+    tries       => $kerberos::kadmin_tries,
+    try_sleep   => $kerberos::kadmin_try_sleep,
   }
 }

--- a/manifests/ktadd.pp
+++ b/manifests/ktadd.pp
@@ -18,6 +18,7 @@ define kerberos::ktadd(
   $kadmin_tries = undef, $kadmin_try_sleep = undef,
   $kadmin_server_package = $kerberos::kadmin_server_package,
   $client_packages = $kerberos::client_packages,
+  $krb5_conf_path = $kerberos::krb5_conf_path,
   $realm = $kerberos::realm,
 ) {
   $ktadd = "ktadd_${keytab}_${principal}"
@@ -50,11 +51,12 @@ define kerberos::ktadd(
 
   $cmd = "ktadd -k ${keytab} ${principal}"
   exec { "ktadd_${keytab}_${principal}":
-    command   => "${kadmin} ${ccache_par} ${keytab_par} -q '${cmd}'",
-    unless    => $unless,
-    path      => [ '/bin', '/usr/bin', '/usr/bin', '/usr/sbin' ],
-    require   => File[$keytab],
-    tries     => $kadmin_tries,
-    try_sleep => $kadmin_try_sleep,
+    command     => "${kadmin} ${ccache_par} ${keytab_par} -q '${cmd}'",
+    unless      => $unless,
+    path        => [ '/bin', '/usr/bin', '/usr/bin', '/usr/sbin' ],
+    environment => "KRB5_CONFIG=${krb5_conf_path}",
+    require     => File[$keytab],
+    tries       => $kadmin_tries,
+    try_sleep   => $kadmin_try_sleep,
   }
 }

--- a/manifests/ticket_cache.pp
+++ b/manifests/ticket_cache.pp
@@ -8,17 +8,18 @@
 # Michael Weiser <michael.weiser@gmx.de>
 #
 define kerberos::ticket_cache ($ccname = $title,
-    $principal = '',
-    $keytab = undef,
-    $service = undef,
-    $pkinit = false,
-    $pkinit_cert = "/var/lib/puppet/ssl/certs/${::fqdn}.pem",
-    $pkinit_key = "/var/lib/puppet/ssl/private_keys/${::fqdn}.pem",
+  $principal = '',
+  $keytab = undef,
+  $service = undef,
+  $pkinit = false,
+  $pkinit_cert = "/var/lib/puppet/ssl/certs/${::fqdn}.pem",
+  $pkinit_key = "/var/lib/puppet/ssl/private_keys/${::fqdn}.pem",
 
-    $client_packages = $kerberos::client_packages,
+  $client_packages = $kerberos::client_packages,
+  $krb5_conf_path = $kerberos::krb5_conf_path,
 
-    # facter fact
-    $kerberos_bootstrap = $::kerberos_bootstrap,
+  # facter fact
+  $kerberos_bootstrap = $::kerberos_bootstrap,
 ) {
   # this needs to be a client in order to run kinit and kadmin
   include kerberos::client
@@ -45,14 +46,15 @@ define kerberos::ticket_cache ($ccname = $title,
 
   $kinit_cmd = "kinit -c '${ccname}' ${keytab_par} ${pkinit_par} ${service_par}"
   exec { "ticket_cache_${title}":
-    command   => "${kinit_cmd} ${principal}",
-    path      => '/usr/bin',
-    require   => [ Package[$client_packages], File['krb5.conf'] ],
+    command     => "${kinit_cmd} ${principal}",
+    path        => '/usr/bin',
+    environment => "KRB5_CONFIG=${krb5_conf_path}",
+    require     => [ Package[$client_packages], File['krb5.conf'] ],
     # always recreate (for now) to avoid expired tickets
     # creates => $ccname
     # if we're bootstrapping no KDC might be up yet and even if not
     # it might just be rebooting
-    tries     => 30,
-    try_sleep => $try_sleep,
+    tries       => 30,
+    try_sleep   => $try_sleep,
   }
 }


### PR DESCRIPTION
if krb5.conf is not located in etc kinit and kadmin need to know where it is, this can be done via the environment KRB5_CONFIG