### PR TITLE
Implement regular key changes

### DIFF
--- a/files/kerberos_ktadd_key_helper.sh
+++ b/files/kerberos_ktadd_key_helper.sh
@@ -1,0 +1,182 @@
+#!/bin/sh
+
+# Due to the way we trick klist into displaying timestamps as seconds since
+# epoch, this script currently is Linux- and MIT-Kerberos-only. The
+# localedef-part was also tested on OS X but not the whole script.
+
+usage() {
+	cat << EOF
+$0 [-c] [-o <seconds>] <keytab> <principal> <max key age>
+
+	-c	client only: Remove all old keys after getting new ones
+	-o <seconds>	Remove all old keys if the current ones are older
+		than the number of seconds given as parameter. Default is
+		to leave one set of old keys in the keytab until the next
+		key change.
+	-n	nagios-compatible dry-run mode
+
+	<keytab>	keytab file to update
+	<principal>	principal to update
+	<max key age>	maximum age of keys before keys are updated
+EOF
+	exit 1
+}
+
+client_only=0
+old_key_preserve_window=0
+dryrun=0
+while getopts "cno:" OPT ; do
+	case "$OPT" in
+		c) client_only=1 ;;
+		n) dryrun=1 ;;
+		o) old_key_preserve_window="$OPTARG" ;;
+		*) usage ;;
+	esac
+done
+
+# shift away all the options parsed by getops and check for the required number
+# of positional arguments
+for i in `seq 2 $OPTIND` ; do shift ; done
+[ "$#" != "3" ] && usage
+
+keytab="$1"
+princ="$2"
+max_key_age="$3"
+
+# Make a temporary directory in which to compile a custom locale.
+lp=$(mktemp -d 2>/dev/null)
+if [ -z "$lp" ] ; then
+	echo "Error creating temporary directory using mktemp" >&2
+	exit 2
+fi
+
+# MIT's klist -t tries to fit the date and time into a fixed-length buffer for
+# aligned printing of the table. For that it tries a number of strftime format
+# strings, the first one being %c - the current locale's appropriate date/time
+# representation. This allows us to override how timestamps are dislpayed. So
+# create a custom locale definition that makes %c print just the seconds since
+# epoch.
+cat <<EOF | LANG=C localedef -c $lp/epoch >/dev/null 2>&1
+LC_TIME
+d_t_fmt "%s"
+END LC_TIME
+EOF
+
+# Unfortunately, since we're using a very sparse locale definiton, localedef
+# will always print warnings and exit with an error although it successfully
+# compiles the locale. So we check if the file we really need was created.
+# Beware: There are cases where localedef will create it but will not put our
+# d_t_fmt into it. This will be caught by the next check.
+if ! [ -f "$lp/epoch/LC_TIME" ] ; then
+	echo "Error compiling custom locale" >&2
+	exit 2
+fi
+
+# Print the keytab contents using our epoch custom locale, filter out entries not
+# listing a kvno, seconds since epoch and our principal, numerically sort by
+# timestamp and get the most current one.
+# glibc: LOCPATH, OS X (/ FreeBSD?): PATH_LOCALE
+ts=$(LOCPATH="$lp" PATH_LOCALE="$lp" LANG=epoch klist -tk "$keytab" | \
+	grep "^[[:space:]]*[0-9]\+[[:space:]]\+[0-9]\+[[:space:]]\+$princ$" | \
+	awk '{ print $2 }' | \
+	sort -n | \
+	tail -n 1)
+
+# Custom locale no longer necessary
+rm -rf "$lp"
+
+# Did we get a timestamp and is it really, really, really just a single number
+# which might suggest, it's seconds since epoch?
+if ! echo "$ts" | grep "^[0-9]\+$" >/dev/null 2>&1 ; then
+	echo "Error determining timestamp of most current set of keys" >&2
+	exit 2
+fi
+
+# Get seconds since epoch for the date our keys are to expire (maximum key
+# age).
+deadline=$(date --date "$max_key_age days ago" +"%s")
+if [ -z "$deadline" ] ; then
+	echo "Error determining timestamp of key change deadline"
+	exit 2
+fi
+
+# Maybe it's not yet time to get a new set of keys but it might be time to
+# throw away a preserved set of old keys.
+preserve_deadline=
+
+if [ "$old_key_preserve_window" != "0" ] ; then
+	# check if there's actually a set of old keys for that principal in the
+	# keytab - tail -n +2 will only return something if there's more than
+	# one line
+	if [ -n "$(klist -k "$keytab" | \
+		grep "^[[:space:]]*[0-9]\+[[:space:]]\+$princ$" | \
+		awk '{ print $1 }' | \
+		sort -un | \
+		tail -n +2)" ] ; then
+		preserve_deadline=$(date --date "$old_key_preserve_window seconds ago" +"%s")
+		if [ -z "$preserve_deadline" ] ; then
+			echo "Error determining timestamp of key preservation window"
+			exit 2
+		fi
+	fi
+fi
+
+if [ "$dryrun" = "1" ] ; then
+	if [ "$ts" -le "$deadline" ] ; then
+		echo "Keys for $princ in keytab $keytab are expired."
+		exit 2
+	fi
+
+	if [ -n "$preserve_deadline" ] && [ "$ts" -le "$preserve_deadline" ] ; then
+		echo "Old set of keys $princ in keytab $keytab should be removed."
+		exit 1
+	fi
+
+	echo "Kerberos keys for $princ in keytab $keytab are current."
+	exit 0
+fi
+
+delold() {
+	do_keytab="$1"
+	do_princ="$2"
+
+	# Stolen from MIT Kerberos' k5srvutil: Remove all but the last set of
+	# keys from the keytab.
+	if ! kadmin -k -t "$do_keytab" -p "$do_princ" \
+		-q "ktrem -k $do_keytab $do_princ old" ; then
+		echo "Error removing old keys for $do_princ from keytab $do_keytab" >&2
+		exit 2
+	fi
+}
+
+# Are the most current keys in the keytab older than our deadline?
+if [ "$ts" -le "$deadline" ] ; then
+	# If this keytab is used for services as well as clients, remove old keys
+	# before getting new ones so that the last set of keys remains after the
+	# update.
+	[ "$client_only" = "0" ] && \
+		[ "$old_key_preserve_window" = "0" ] && \
+		delold "$keytab" "$princ"
+
+	# Stolen from MIT Kerberos' k5srvutil: Get new set of keys.
+	if ! kadmin -k -t "$keytab" -p "$princ" \
+		-q "ktadd -k $keytab $princ" ; then
+		echo "Error getting new set of keys for $princ and keytab $keytab"
+		exit 2
+	fi
+
+	# If this keytab is used for clients only, remove old keys after getting new
+	# ones so that only the current set remains.
+	[ "$client_only" = "0" ] || \
+		delold "$keytab" "$princ"
+else
+	if [ -n "$preserve_deadline" ] && [ "$ts" -le "$preserve_deadline" ] ; then
+		# Last set of keys was written to the keytab more than
+		# $old_key_preserve_window seconds ago. That means, we can
+		# assume that all tickets using those keys are now expired. So
+		# we can trash all old keys.
+		delold "$keytab" "$princ"
+	fi
+fi
+
+exit 0

--- a/files/kerberos_ktadd_key_helper_test.sh
+++ b/files/kerberos_ktadd_key_helper_test.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+d=$(mktemp -d)
+k="$d"/t.keytab
+p1=a/b@C.D
+p2=e/f@C.D
+
+hwclock --systohc
+
+ktadd() {
+	date="$1"
+	kvno="$2"
+	date -s "$1"
+
+	cat << EOF | ktutil
+addent -password -p $p1 -k $kvno -e arcfour-hmac
+a
+addent -password -p $p2 -k $kvno -e arcfour-hmac
+a
+wkt $k
+quit
+EOF
+}
+
+ktadd "90 days ago" 1
+ktadd "15 days" 2
+ktadd "15 days" 3
+ktadd "15 days" 4
+ktadd "15 days" 5
+ktadd "15 days" 6
+
+hwclock --hctosys
+
+# check state of keytab
+while read expected_rc princ max_key_age opts ; do
+	./kerberos_ktadd_key_helper.sh -n $opts "$k" $princ $max_key_age
+	rc="$?"
+	if [ "$rc" != "$expected_rc" ] ; then
+		echo "Unexpected rc $rc vs. $expected_rc on test $k:$princ:$max_key_age:$opts"
+		exit 1
+	fi
+done <<EOF
+0 $p1 100
+0 $p1 100 -c
+1 $p1 100 -o 10
+2 $p1 10
+2 $p1 10 -c
+2 $p1 10 -o 10
+EOF
+rc="$?"
+
+rm -rf "$d"
+exit "$rc"

--- a/manifests/addprinc_keytab_ktadd.pp
+++ b/manifests/addprinc_keytab_ktadd.pp
@@ -15,7 +15,11 @@ define kerberos::addprinc_keytab_ktadd(
   $kadmin_tries = undef, $kadmin_try_sleep = undef,
   # only here for host_keytab - define keytab directly if specific permissions
   # are desired
-  $keytab_owner = 0, $keytab_group = 0, $keytab_mode = '0400'
+  $keytab_owner = 0, $keytab_group = 0, $keytab_mode = '0600',
+  $ktadd_max_key_age = $kerberos::ktadd_max_key_age,
+  $ktadd_client_only = $kerberos::ktadd_client_only,
+  $ktadd_cronjob_hour = $kerberos::ktadd_cronjob_hour,
+  $ktadd_cronjob_minute = $kerberos::ktadd_cronjob_minute,
 ) {
   if $local == false {
     include kerberos::host_ticket_cache
@@ -56,6 +60,11 @@ define kerberos::addprinc_keytab_ktadd(
       kadmin_keytab    => $kadmin_keytab,
       kadmin_tries     => $kadmin_tries,
       kadmin_try_sleep => $kadmin_try_sleep,
+      keytab_owner     => $keytab_owner,
+      max_key_age      => $ktadd_max_key_age,
+      client_only      => $ktadd_client_only,
+      cronjob_hour     => $ktadd_cronjob_hour,
+      cronjob_minute   => $ktadd_cronjob_minute,
     }
   }
 

--- a/manifests/host_keytab.pp
+++ b/manifests/host_keytab.pp
@@ -7,8 +7,9 @@
 # Michael Weiser <michael.weiser@gmx.de>
 #
 define kerberos::host_keytab($princs = [ $title ], $spnego = false,
-  $owner = $title, $group = 0, $mode = '0400',
+  $owner = $title, $group = 0, $mode = '0600',
   $host_ticket_cache_ccname = $kerberos::host_ticket_cache_ccname,
+  $realm = $kerberos::realm,
 ) {
   # hack to get $kerberos::host_ticket_cache_ccname initialised
   include kerberos
@@ -39,6 +40,7 @@ define kerberos::host_keytab($princs = [ $title ], $spnego = false,
     $keytab_http = '/etc/hadoop-spnego.keytab'
     $principal_http = "HTTP/${::fqdn}"
     $ktadd_http = "${keytab_http}@${principal_http}"
+    $ktadd_http_exec = "ktadd_${keytab_http}_${principal_http}"
     if !defined(Kerberos::Addprinc_keytab_ktadd[$ktadd_http]) {
       kerberos::addprinc_keytab_ktadd { $ktadd_http:
         local         => false,
@@ -46,19 +48,33 @@ define kerberos::host_keytab($princs = [ $title ], $spnego = false,
       }
     }
 
+    # commands to remove old keys from the target keytab and copy over new ones
+    $remoldkeys_princ = $actual_principals[0]
+    $remoldkeys = "kadmin -k -t '${keytab}' -p '${remoldkeys_princ}' \
+      -q 'ktrem -k ${keytab} ${principal_http} all'"
+    $copykeys = "ktutil <<EOF
+rkt ${keytab_http}
+wkt ${keytab}
+EOF"
+
+    # commands that extract kvnos of a principal from the keytabs and format
+    # them to be string-comparable
+    $normkvnos = "awk '{print \$1}' | sort | tr '\\n' ' '"
+    $getkvnos = "grep ' ${principal_http}@${realm}' | ${normkvnos}"
+    $getkvnos_kt = "klist -k '${keytab}' | ${getkvnos}"
+    $getkvnos_http = "klist -k '${keytab_http}' | ${getkvnos}"
+
     # create the HTTP keytab and then interject the HTTP principal between
     # keytab creation and first principal addition so that we're finished with
     # this when the actual addprinc_keytab_ktadd is finished
-    Kerberos::Addprinc_keytab_ktadd[$ktadd_http] ->
+    $ktadd_execs = prefix(prefix($actual_principals, "${keytab}_"), 'ktadd_')
+    Exec[$ktadd_http_exec] ->
     Kerberos::Keytab[$keytab] ->
     exec { "krb5-ktutil-${keytab_http}-${keytab}":
-      command => "ktutil <<EOF
-rkt ${keytab_http}
-wkt ${keytab}
-EOF",
-      path    => [ '/bin', '/usr/bin' ],
-      unless  => "klist -k '${keytab}' | grep ' ${principal_http}@'",
+      command => "${remoldkeys} ; ${copykeys}",
+      path    => [ '/bin', '/usr/bin', '/sbin', '/usr/sbin' ],
+      unless  => "test \"`${getkvnos_kt}`\" = \"`${getkvnos_http}`\"",
     } ->
-    Kerberos::Ktadd[$ktadds]
+    Exec[$ktadd_execs]
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -140,6 +140,28 @@
 # $host_ticket_cache_principal
 #   When creating a ticket cache for use by kadmin use these parameters.
 #
+# $ktadd_max_key_age
+#   Default for maximum age of keys in keytab files in days. If greater than
+#   zero, a cron job is installed that regularly checks for timestamps of keys
+#   for principals and runs the equivalent of k5srvutil change & delold.
+#
+# $ktadd_client_only
+#   Whether to preserve only the current set of keys or the last set as well.
+#   The latter is needed for services to continue to function while tickets
+#   using the old keys are still in use.
+#
+# $ktadd_cronjob_hour
+# $ktadd_cronjob_minute
+#   When to run the key age check cron job.
+#
+# $ktadd_key_helper
+#   The command to use when checking and possibly updating keys in keytabs.
+#
+# $ktadd_check_helper
+#   Base name of helper scripts to generate for checking if keys are current.
+#   Defaults to undef, meaning that no scripts will be created. Set to e.g.
+#   /usr/local/bin/kerberos_ktadd_check to enable.
+#
 # $pkinit_packages
 # $client_packages
 # $kdc_server_package
@@ -198,7 +220,7 @@ class kerberos(
   $kdc_database_path = $kerberos::params::kdc_database_path,
   $kdc_database_password = undef,
   $kdc_stash_path = $kerberos::params::kdc_stash_path,
-  $kdc_max_life = '10h 0m 0s',
+  $kdc_max_life = 10 * 60 * 60, # '0d 10h 0m 0s'
   $kdc_max_renewable_life = '7d 0h 0m 0s',
   $kdc_master_key_type = 'aes256-cts',
   $kdc_supported_enctypes = [ 'aes256-cts:normal',
@@ -232,6 +254,13 @@ class kerberos(
   $host_ticket_cache_ccname = '/var/lib/puppet/krb5cc.puppet',
   $host_ticket_cache_service = 'kadmin/admin',
   $host_ticket_cache_principal = $fqdn,
+
+  $ktadd_max_key_age = 60, # days
+  $ktadd_client_only = false,
+  $ktadd_cronjob_hour = '*',
+  $ktadd_cronjob_minute = '2',
+  $ktadd_key_helper = '/usr/local/bin/kerberos_ktadd_key_helper',
+  $ktadd_check_helper = undef,
 
   $pkinit_cert = $kerberos::params::pkinit_cert,
   $pkinit_key  = $kerberos::params::pkinit_key,

--- a/manifests/keytab.pp
+++ b/manifests/keytab.pp
@@ -9,7 +9,7 @@
 #
 
 define kerberos::keytab($keytab = $title,
-  $mode = '0400', $owner = 0, $group = 0,
+  $mode = '0600', $owner = 0, $group = 0,
   $replace = false,
 ) {
   # TODO: Avoid recreation if already existing but do update if keys get to

--- a/manifests/ktadd.pp
+++ b/manifests/ktadd.pp
@@ -20,6 +20,14 @@ define kerberos::ktadd(
   $client_packages = $kerberos::client_packages,
   $krb5_conf_path = $kerberos::krb5_conf_path,
   $realm = $kerberos::realm,
+  $max_key_age = $kerberos::ktadd_max_key_age,
+  $client_only = $kerberos::ktadd_client_only,
+  $keytab_owner = undef,
+  $cronjob_hour = $kerberos::ktadd_cronjob_hour,
+  $cronjob_minute = $kerberos::ktadd_cronjob_minute,
+  $kdc_max_life = $kerberos::kdc_max_life,
+  $ktadd_key_helper = $kerberos::ktadd_key_helper,
+  $ktadd_check_helper = $kerberos::ktadd_check_helper,
 ) {
   $ktadd = "ktadd_${keytab}_${principal}"
   if $local {
@@ -50,7 +58,7 @@ define kerberos::ktadd(
   }
 
   $cmd = "ktadd -k ${keytab} ${principal}"
-  exec { "ktadd_${keytab}_${principal}":
+  exec { $ktadd:
     command     => "${kadmin} ${ccache_par} ${keytab_par} -q '${cmd}'",
     unless      => $unless,
     path        => [ '/bin', '/usr/bin', '/usr/bin', '/usr/sbin' ],
@@ -58,5 +66,103 @@ define kerberos::ktadd(
     require     => File[$keytab],
     tries       => $kadmin_tries,
     try_sleep   => $kadmin_try_sleep,
+  }
+
+  # calculate some values we need later on
+  $ktcron_job = "${ktadd} key change cron job"
+  $ktcheck_suffix = regsubst("${keytab}_${principal}", '[\./@]', '_', 'G')
+  $ktcheck = "${ktadd_check_helper}${ktcheck_suffix}"
+
+  # potentially install a key change cron job for the newly added principal
+  if $max_key_age > 0 {
+    if is_integer($kdc_max_life) {
+      if $client_only {
+        # clean out all old keys since a client only needs the current set
+        $delold = '-c'
+        $delold_ktc = ''
+      } else {
+        # remove old keys when the current set got older than the maximum
+        # allowed ticket lifetime plus an hour for safety
+        $old_key_preserve_window = $kdc_max_life + 3600
+        $delold = "-o '${old_key_preserve_window}'"
+
+        # be less strict about key deletion when checking to avoid false
+        # positives and flapping
+        $old_key_preserve_window_ktc = $kdc_max_life + 7200
+        $delold_ktc = "-o '${old_key_preserve_window_ktc}'"
+      }
+
+      # be less strict about key expiry when checking to avoid false
+      # positives and flapping
+      $max_key_age_ktc = $max_key_age + 1
+    } else {
+      warning('Please specify kdc_max_life in seconds as integer.')
+      warning('Otherwise, maximum key age plausibility checks for keytab')
+      warning('entries can not be implemented and old keys have to be left')
+      warning('in the keytab longer than necessary.')
+
+      if $client_only {
+        # clean out all old keys since a client only needs the current set
+        $delold = '-c'
+      } else {
+        # the key helper script defaults to leaving one set of old keys in
+        # until the next key update
+        $delold = ''
+      }
+      $delold_ktc = ''
+    }
+
+    # construct helper commands
+    $ktadd_o = "'${keytab}' '${principal}@${realm}'"
+    $ktcron_cmd = "${ktadd_key_helper} ${delold} ${ktadd_o} '${max_key_age}'"
+    $ktcheck_cmd = "${ktadd_key_helper} -n ${delold_ktc} ${ktadd_o} '${max_key_age_ktc}'"
+
+    if !defined(File[$ktadd_key_helper]) {
+      # install helper script for key updates and age checks
+      file { $ktadd_key_helper:
+        mode    => '0755',
+        owner   => 0,
+        group   => 0,
+        source  => 'puppet:///modules/kerberos/kerberos_ktadd_key_helper.sh',
+        # uses klist to list and kadmin to change keys
+        require => Package[$client_packages],
+      }
+    }
+
+    # install the actual key age check and update cron job
+    cron { $ktcron_job:
+      ensure  => present,
+      command => $ktcron_cmd,
+      user    => $keytab_owner,
+      hour    => $cronjob_hour,
+      minute  => $cronjob_minute,
+      require => [File[$keytab], File[$ktadd_key_helper]],
+    }
+
+    # optionally install a helper script that can be used to check if the keys
+    # are up to date
+    if $ktadd_check_helper {
+      file { $ktcheck:
+        mode    => '0755',
+        owner   => 0,
+        group   => 0,
+        content => "#\$!/bin/bash\nexec ${ktcheck_cmd}\n",
+        # uses klist to list and kadmin to change keys
+        require => File[$ktadd_key_helper],
+      }
+    }
+  } else {
+    # remove stuff we don't need. Can't remove the key helper script, because
+    # that's shared amongst all ktadd resource instances.
+    cron { $ktcron_job:
+      ensure => absent,
+      user   => $keytab_owner,
+    }
+
+    if $ktadd_check_helper {
+      file { $ktcheck:
+        ensure => absent,
+      }
+    }
   }
 }

--- a/manifests/server/base.pp
+++ b/manifests/server/base.pp
@@ -33,6 +33,12 @@ class kerberos::server::base (
   $kdc_conf_dir = dirname($kdc_conf_path)
   ensure_resource('file', $kdc_conf_dir, { ensure => 'directory' })
 
+  if is_integer($kdc_max_life) {
+    $max_life_str = "${kdc_max_life}s"
+  } else {
+    $max_life_str = $kdc_max_life
+  }
+
   file { 'kdc.conf':
     ensure  => file,
     path    => $kdc_conf_path,


### PR DESCRIPTION
Extend the ktadd type to use a helper script to check for key expiry and
renewal. Also takes care of leaving old sets of keys in the keytab as
long as there might be tickets around still encrypted with them. Can
optionally create keytab/principal-specific helper scripts to be u sed
for individual checks such as usually implemented via monitoring.