### PR TITLE
do not force $krb5_conf_dir to be a directory

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -44,7 +44,7 @@ class kerberos::client (
   }
 
   $krb5_conf_dir = dirname($krb5_conf_path)
-  ensure_resource('file', $krb5_conf_dir, { ensure => 'directory' })
+  ensure_resource('file', $krb5_conf_dir, { ensure => 'directory', replace => false })
 
   file { 'krb5.conf':
     ensure  => file,


### PR DESCRIPTION
 do not force $krb5_conf_dir to be a directory there might be an existing symlink