### PR TITLE
Don't manage the configuration dir

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -12,16 +12,16 @@
 # Copyright 2013 Jason Edgecombe, unless otherwise noted.
 #
 class kerberos::client (
-  $krb5_conf_path = $kerberos::krb5_conf_path,
-  $realm = $kerberos::realm,
-  $domain_realm = $kerberos::domain_realm,
-  $kdcs = $kerberos::kdcs,
-  $master_kdc = $kerberos::master_kdc,
-  $admin_server = $kerberos::admin_server,
+  $krb5_conf_path    = $kerberos::krb5_conf_path,
+  $realm             = $kerberos::realm,
+  $domain_realm      = $kerberos::domain_realm,
+  $kdcs              = $kerberos::kdcs,
+  $master_kdc        = $kerberos::master_kdc,
+  $admin_server      = $kerberos::admin_server,
   $allow_weak_crypto = $kerberos::allow_weak_crypto,
-  $forwardable = $kerberos::forwardable,
-  $proxiable = $kerberos::proxiable,
-  $pkinit_anchors = $kerberos::pkinit_anchors_cfg,
+  $forwardable       = $kerberos::forwardable,
+  $proxiable         = $kerberos::proxiable,
+  $pkinit_anchors    = $kerberos::pkinit_anchors_cfg,
 
   $client_packages = $kerberos::client_packages,
 ) inherits kerberos {
@@ -40,12 +40,8 @@ class kerberos::client (
 
   package { $client_packages:
     ensure => present,
-    before => File['krb5.conf'],
   }
-
-  $krb5_conf_dir = dirname($krb5_conf_path)
-  ensure_resource('file', $krb5_conf_dir, { ensure => 'directory', replace => false })
-
+  ->
   file { 'krb5.conf':
     ensure  => file,
     path    => $krb5_conf_path,
@@ -53,6 +49,5 @@ class kerberos::client (
     mode    => '0644',
     owner   => 0,
     group   => 0,
-    require => File[$krb5_conf_dir],
   }
 }

--- a/manifests/server/base.pp
+++ b/manifests/server/base.pp
@@ -14,24 +14,21 @@
 # Copyright 2013 Jason Edgecombe, unless otherwise noted.
 #
 class kerberos::server::base (
-  $kdc_conf_path = $kerberos::kdc_conf_path,
-
-  $realm = $kerberos::realm,
-  $kdc_ports = $kerberos::kdc_ports,
-  $kdc_database_path = $kerberos::kdc_database_path,
-  $kdc_stash_path = $kerberos::kdc_stash_path,
-  $kdc_max_life = $kerberos::kdc_max_life,
+  $kdc_conf_path          = $kerberos::kdc_conf_path,
+  $realm                  = $kerberos::realm,
+  $kdc_ports              = $kerberos::kdc_ports,
+  $kdc_database_path      = $kerberos::kdc_database_path,
+  $kdc_stash_path         = $kerberos::kdc_stash_path,
+  $kdc_max_life           = $kerberos::kdc_max_life,
   $kdc_max_renewable_life = $kerberos::kdc_max_renewable_life,
-  $kdc_master_key_type = $kerberos::kdc_master_key_type,
+  $kdc_master_key_type    = $kerberos::kdc_master_key_type,
   $kdc_supported_enctypes = $kerberos::kdc_supported_enctypes,
-  $pkinit_anchors = $kerberos::pkinit_anchors_cfg,
-  $kdc_pkinit_identity = $kerberos::kdc_pkinit_identity_cfg,
-  $kdc_logfile = $kerberos::kdc_logfile_cfg,
-  $kadmind_logfile = $kerberos::kadmind_logfile_cfg,
+  $pkinit_anchors         = $kerberos::pkinit_anchors_cfg,
+  $kdc_pkinit_identity    = $kerberos::kdc_pkinit_identity_cfg,
+  $kdc_logfile            = $kerberos::kdc_logfile_cfg,
+  $kadmind_logfile        = $kerberos::kadmind_logfile_cfg,
 ) inherits kerberos {
   require stdlib
-  $kdc_conf_dir = dirname($kdc_conf_path)
-  ensure_resource('file', $kdc_conf_dir, { ensure => 'directory' })
 
   file { 'kdc.conf':
     ensure  => file,
@@ -40,6 +37,5 @@ class kerberos::server::base (
     mode    => '0644',
     owner   => 0,
     group   => 0,
-    require => File[$kdc_conf_dir],
   }
 }


### PR DESCRIPTION
This solves a problem I ran into:

```puppet
Error: Failed to apply catalog: Found 1 dependency cycle:
(Exec[import-CentOS 6] => Repos::Rpm_gpg_key[CentOS 6] => Class[Repos::Rpm::Gpg_keys] => Stage[setup] => Stage[main] => Class[Kerberos::Client] => File[/etc] => File[/etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6] => Repos::Rpm_gpg_key[CentOS 6])
```

I have /etc managed at an earlier stage. Whenever ensure_resource tries to manage it, it creates a duplicate entry. I think we can go without ensuring the directory's presence.