### PR TITLE
Accept additional data structure for $extra_realms param

### DIFF
--- a/templates/krb5.conf.erb
+++ b/templates/krb5.conf.erb
@@ -33,25 +33,32 @@
 <% end -%>
         }
 <% if ! @extra_realms.empty? -%>
-<% @extra_realms.each_pair do |realm, relations| -%>
-<% if relations -%>
+<%   @extra_realms.each_pair do |realm, relations| -%>
+<%     if relations -%>
         <%= realm %> = {
-<% if relations.is_a? Array -%>
-<% relations.each do |relation| -%>
-<% relation.each_pair do |key, val| -%>
+<%       if relations.is_a? Array -%>
+<%         relations.each do |relation| -%>
+<%           relation.each_pair do |key, val| -%>
                 <%= key %> = <%= val %>
-<% end -%>
-<% end -%>
-<% elsif relations.is_a? Hash -%>
-<% relations.each_pair do |key, val| -%>
+<%           end -%>
+<%         end -%>
+<%       elsif relations.is_a? Hash -%>
+<%         relations.each_pair do |key, val| -%>
+<%           if val.is_a? String -%>
                 <%= key %> = <%= val %>
-<% end -%>
-<% end -%>
+<%           elsif val.is_a? Array -%>
+<%# When we have 'kdc' => ['a', 'b'] we loop through values and repeat the key: -%>
+<%             val.each do |v| -%>
+                <%= key %> = <%= v %>
+<%             end -%>
+<%           end -%>
+<%         end -%>
+<%       end -%>
         }
-<% else -%>
+<%     else -%>
         <%= realm %> = {}
-<% end -%>
-<% end -%>
+<%     end -%>
+<%   end -%>
 <% end -%>
 
 [domain_realm]

--- a/templates/krb5.conf.erb
+++ b/templates/krb5.conf.erb
@@ -36,8 +36,14 @@
 <% @extra_realms.each_pair do |realm, relations| -%>
 <% if relations -%>
         <%= realm %> = {
+<% if relations.is_a? Array -%>
 <% relations.each do |relation| -%>
 <% relation.each_pair do |key, val| -%>
+                <%= key %> = <%= val %>
+<% end -%>
+<% end -%>
+<% elsif relations.is_a? Hash -%>
+<% relations.each_pair do |key, val| -%>
                 <%= key %> = <%= val %>
 <% end -%>
 <% end -%>


### PR DESCRIPTION
Hi,

I wanted to use a differente structure for extra_realms parameter.
Something looking like this:

```yaml
extra_realms:
  foo.example.com:
    kdc:
    - ds1.foo.example.com
    - ds2.foo.example.com
    admin_server: ds1.foo.example.com
```

Instead of:

```yaml
extra_realms:
  foo.example.com:
    - kdc: ds1.foo.example.com
    - kdc: ds2.foo.example.com
    - admin_server: ds1.foo.example.com
```

Array of "single entry Hash" look strange to me and I really prefer pure Hash with Array when declaring multiple values for kdc.

This patch does not break anything else and still allow both data struct.
Please let me known if you would like documentation about this alternative input format, I'll be glad to write it.

Regards,